### PR TITLE
docs: correct L1 clustering description from pHash to HDBSCAN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This file provides context and instructions for AI coding agents working with th
 ## Project Overview
 
 PIC is a hierarchical image clustering API for product catalog images. Two-level clustering:
-- **Level 1**: Near-duplicate detection (same product, different angles) via perceptual hashing
+- **Level 1**: Near-duplicate detection (same product, different angles) via HDBSCAN on DINOv2 cosine distance
 - **Level 2**: Semantic similarity (visually similar products) via DINOv2 embeddings + UMAP + HDBSCAN
 
 ## Commands
@@ -80,7 +80,7 @@ A `Makefile` provides shortcuts: `make dev`, `make test`, `make test-all`, `make
 
 **Google Drive sync flow**: `POST /api/v1/gdrive/sync` or automatic via Modal cron (every 15 min). Tier 1 (CPU cron) checks GDrive for new images -> if found, spawns Tier 2 (GPU worker) that downloads images, computes hashes + embeddings, uploads to S3, moves processed files to GDrive `processed/` subfolder, then runs clustering. Uses same advisory lock as pipeline.
 
-**Key tech choices**: DINOv2 (visual similarity without text bias), pgvector (single DB for metadata + vectors), UMAP + HDBSCAN (60% quality gain over raw high-dim clustering), pHash for L1 (deterministic, fast), Modal (serverless GPU).
+**Key tech choices**: DINOv2 (visual similarity without text bias), pgvector (single DB for metadata + vectors), UMAP + HDBSCAN (60% quality gain over raw high-dim clustering), HDBSCAN on DINOv2 cosine distance for L1 (density-based near-duplicate grouping), pHash for duplicate search API, Modal (serverless GPU).
 
 ## Code Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Initial open-source release of PIC (Product Image Clustering)
-- Two-level hierarchical clustering: pHash (L1) + DINOv2/HDBSCAN (L2)
+- Two-level hierarchical clustering: HDBSCAN on DINOv2 cosine distance (L1) + UMAP/HDBSCAN on DINOv2 embeddings (L2)
 - FastAPI REST API with image, cluster, product, search, and pipeline endpoints
 - Modal serverless GPU workers for embedding generation and clustering
 - Google Drive sync integration for automated image ingestion

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Hierarchical image clustering API for product catalog images. Two-level clustering automatically organizes thousands of product images into meaningful groups:
 
-- **Level 1**: Groups images of the exact same product (different angles, zoom levels) using perceptual hashing
+- **Level 1**: Groups images of the exact same product (different angles, zoom levels) using HDBSCAN on DINOv2 cosine distance
 - **Level 2**: Groups visually similar products (shared design, style, or category) using DINOv2 embeddings + HDBSCAN
 
 ## Features
@@ -54,7 +54,7 @@ API docs available at http://localhost:8000/docs
 
 PIC uses a two-level clustering approach:
 
-1. **Level 1 (L1)** -- Perceptual hashing groups identical products photographed from different angles. Fast, deterministic, and runs on CPU.
+1. **Level 1 (L1)** -- HDBSCAN on DINOv2 cosine distance groups identical products photographed from different angles. Density-based clustering runs on CPU (embeddings computed on GPU).
 2. **Level 2 (L2)** -- DINOv2 embeddings + UMAP dimensionality reduction + HDBSCAN clustering groups visually similar products. Runs on GPU for embedding computation.
 
 **Components**:
@@ -69,7 +69,7 @@ PIC uses a two-level clustering approach:
 **Flows**:
 
 - **Ingestion**: Upload images to S3 `images/` prefix -> compute pHash + DINOv2 embedding -> store vectors in PostgreSQL -> move to `processed/`
-- **Clustering**: Triggered via API or pipeline. Runs UMAP + HDBSCAN on all embedded images.
+- **Clustering**: Triggered via API or pipeline. L1 runs HDBSCAN on DINOv2 cosine distance; L2 runs UMAP + HDBSCAN on DINOv2 embeddings.
 - **Pipeline**: Single endpoint for n8n/automation -- discovers, deduplicates, ingests, and clusters in one call.
 - **Google Drive sync**: Watches a Drive folder, downloads new images, processes them, and syncs to S3.
 

--- a/docs/deployment/modal-setup.md
+++ b/docs/deployment/modal-setup.md
@@ -36,7 +36,7 @@ modal deploy src/pic/modal_app.py --tag "v0.1.0"
 
 This deploys:
 - `run_ingest_job` -- Processes uploaded images (download, hash, store metadata)
-- `run_cluster_job` -- Runs hierarchical clustering (L1 pHash + L2 DINOv2/HDBSCAN)
+- `run_cluster_job` -- Runs hierarchical clustering (L1 HDBSCAN on cosine distance + L2 UMAP/HDBSCAN on DINOv2 embeddings)
 - `run_pipeline_job` -- End-to-end pipeline (discover, dedup, ingest, cluster)
 - `run_gdrive_sync_job` -- Syncs images from Google Drive
 - `check_modal_job_status` -- Health check endpoint


### PR DESCRIPTION
## Summary
- Fixed incorrect L1 clustering description across all documentation
- L1 clustering uses **HDBSCAN on DINOv2 cosine distance**, not perceptual hashing (pHash)
- pHash is computed during ingestion but used only by the `/search` duplicate detection endpoint

## Files Changed
- **README.md**: Fixed 3 references (intro, architecture, flows sections)
- **AGENTS.md**: Fixed 2 references (overview, key tech choices)
- **CHANGELOG.md**: Fixed 1 reference (v0.1.0 release notes)
- **docs/deployment/modal-setup.md**: Fixed 1 reference (Modal function description)

## Verification
Confirmed via source code:
- `src/pic/services/clustering.py` → `cluster_level1()` uses HDBSCAN on cosine distance
- `src/pic/services/clustering_pipeline.py` → L1 comment: "HDBSCAN on cosine distance"
- `src/pic/config.py` → L1 section header: "HDBSCAN on cosine distance"
- `src/pic/api/search.py` → pHash is used here for duplicate search, not clustering

## Test plan
- [ ] Verify documentation reads accurately against source code
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)