### PR TITLE
docs: remove empty Unreleased section from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.1.0] - 2026-02-24
 
 ### Added
@@ -24,5 +22,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker Compose for local development
 - CI/CD pipeline with GitHub Actions
 
-[Unreleased]: https://github.com/masa-57/pic/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/masa-57/pic/releases/tag/v0.1.0


### PR DESCRIPTION
Removes the empty `Unreleased` placeholder from CHANGELOG.md so it matches the published v0.1.0 release state.