### PR TITLE
docs: add architecture and pipeline diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Hierarchical image clustering API for product catalog images. Two-level clusteri
 - **Level 1**: Groups images of the exact same product (different angles, zoom levels) using HDBSCAN on DINOv2 cosine distance
 - **Level 2**: Groups visually similar products (shared design, style, or category) using DINOv2 embeddings + HDBSCAN
 
+<p align="center">
+  <img src="docs/images/pipeline-demo.svg" alt="PIC Pipeline Demo" width="900"/>
+</p>
+
 ## Features
 
 - Two-level hierarchical clustering (near-duplicate detection + semantic similarity)
@@ -51,6 +55,10 @@ uv run fastapi dev src/pic/main.py
 API docs available at http://localhost:8000/docs
 
 ## Architecture
+
+<p align="center">
+  <img src="docs/images/architecture.svg" alt="PIC Architecture" width="900"/>
+</p>
 
 PIC uses a two-level clustering approach:
 

--- a/docs/deployment/architecture.md
+++ b/docs/deployment/architecture.md
@@ -2,6 +2,8 @@
 
 PIC (Product Image Clustering) consists of four main components that can be deployed on any infrastructure.
 
+![Architecture Diagram](../images/architecture.svg)
+
 ## Components
 
 ```

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -1,0 +1,173 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 620" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <filter id="shadow" x="-4%" y="-4%" width="108%" height="112%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.1"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#3b82f6"/>
+    </marker>
+    <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#334155"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1100" height="620" rx="12" fill="#f8fafc"/>
+
+  <!-- Header -->
+  <rect x="0" y="0" width="1100" height="56" rx="12" fill="url(#headerGrad)"/>
+  <rect x="0" y="24" width="1100" height="32" fill="url(#headerGrad)"/>
+  <text x="550" y="36" text-anchor="middle" fill="white" font-size="18" font-weight="600">PIC — Product Image Clustering Architecture</text>
+
+  <!-- ===== LEFT COLUMN: Input Sources ===== -->
+  <!-- Client / Upload -->
+  <rect x="30" y="85" width="160" height="70" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="110" y="113" text-anchor="middle" fill="#1e40af" font-size="11" font-weight="600">CLIENT</text>
+  <text x="110" y="130" text-anchor="middle" fill="#3b82f6" font-size="10">REST API / Upload</text>
+  <text x="110" y="143" text-anchor="middle" fill="#64748b" font-size="9">Images + API Key</text>
+
+  <!-- Google Drive Sync -->
+  <rect x="30" y="175" width="160" height="60" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="110" y="200" text-anchor="middle" fill="#166534" font-size="11" font-weight="600">GOOGLE DRIVE</text>
+  <text x="110" y="216" text-anchor="middle" fill="#16a34a" font-size="10">Sync Pipeline</text>
+  <text x="110" y="229" text-anchor="middle" fill="#64748b" font-size="9">Batch import</text>
+
+  <!-- ===== MIDDLE-LEFT: API Layer ===== -->
+  <rect x="240" y="85" width="190" height="190" rx="10" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="240" y="85" width="190" height="32" rx="10" fill="#1e293b"/>
+  <rect x="240" y="105" width="190" height="12" fill="#1e293b"/>
+  <text x="335" y="105" text-anchor="middle" fill="white" font-size="12" font-weight="600">FastAPI (Railway)</text>
+  <text x="335" y="105" text-anchor="middle" fill="white" font-size="12" font-weight="600">FastAPI (Railway)</text>
+
+  <text x="260" y="140" fill="#334155" font-size="10" font-weight="500">Python 3.12 · Async</text>
+  <text x="260" y="157" fill="#64748b" font-size="9.5">→ Image upload &amp; validation</text>
+  <text x="260" y="172" fill="#64748b" font-size="9.5">→ API key auth (HMAC)</text>
+  <text x="260" y="187" fill="#64748b" font-size="9.5">→ Rate limiting</text>
+  <text x="260" y="202" fill="#64748b" font-size="9.5">→ RFC 7807 error responses</text>
+  <text x="260" y="217" fill="#64748b" font-size="9.5">→ Prometheus metrics</text>
+  <text x="260" y="232" fill="#64748b" font-size="9.5">→ Structured JSON logging</text>
+  <text x="260" y="250" fill="#94a3b8" font-size="8.5" font-style="italic">SQLAlchemy 2.0 async</text>
+  <text x="260" y="264" fill="#94a3b8" font-size="8.5" font-style="italic">Sentry error tracking</text>
+
+  <!-- ===== MIDDLE: Database ===== -->
+  <rect x="240" y="305" width="190" height="95" rx="10" fill="#faf5ff" stroke="#e9d5ff" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="335" y="332" text-anchor="middle" fill="#6b21a8" font-size="12" font-weight="600">PostgreSQL + pgvector</text>
+  <text x="260" y="352" fill="#7c3aed" font-size="9.5">768-dim embeddings (HNSW)</text>
+  <text x="260" y="367" fill="#7c3aed" font-size="9.5">ACID transactions</text>
+  <text x="260" y="382" fill="#7c3aed" font-size="9.5">Advisory locks (0x4E494301)</text>
+  <text x="260" y="395" fill="#a78bfa" font-size="8.5">17 Alembic migrations</text>
+
+  <!-- ===== MIDDLE-RIGHT: Object Storage ===== -->
+  <rect x="240" y="425" width="190" height="55" rx="10" fill="#fff7ed" stroke="#fed7aa" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="335" y="450" text-anchor="middle" fill="#9a3412" font-size="11" font-weight="600">Cloudflare R2</text>
+  <text x="335" y="466" text-anchor="middle" fill="#ea580c" font-size="10">Image Object Storage</text>
+
+  <!-- ===== RIGHT COLUMN: GPU Compute ===== -->
+  <rect x="500" y="85" width="220" height="175" rx="10" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="500" y="85" width="220" height="32" rx="10" fill="#7c3aed"/>
+  <rect x="500" y="105" width="220" height="12" fill="#7c3aed"/>
+  <text x="610" y="105" text-anchor="middle" fill="white" font-size="12" font-weight="600">Modal (Serverless GPU)</text>
+
+  <text x="520" y="140" fill="#334155" font-size="10" font-weight="600">Embedding Worker</text>
+  <text x="520" y="156" fill="#64748b" font-size="9.5">→ DINOv2 ViT (768-dim)</text>
+  <text x="520" y="171" fill="#64748b" font-size="9.5">→ A100 GPU on demand</text>
+
+  <text x="520" y="195" fill="#334155" font-size="10" font-weight="600">Clustering Pipeline</text>
+  <text x="520" y="211" fill="#64748b" font-size="9.5">→ L1: HDBSCAN (near-dupes)</text>
+  <text x="520" y="226" fill="#64748b" font-size="9.5">→ L2: UMAP + HDBSCAN</text>
+  <text x="520" y="241" fill="#64748b" font-size="9.5">→ Atomic rollback on failure</text>
+  <text x="520" y="253" fill="#94a3b8" font-size="8.5" font-style="italic">&lt; 30s cold start</text>
+
+  <!-- ===== FAR RIGHT: AI Integration ===== -->
+  <rect x="500" y="285" width="220" height="75" rx="10" fill="#fefce8" stroke="#fef08a" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="610" y="310" text-anchor="middle" fill="#854d0e" font-size="11" font-weight="600">Google Gemini</text>
+  <text x="520" y="330" fill="#a16207" font-size="9.5">→ Product tag generation</text>
+  <text x="520" y="345" fill="#a16207" font-size="9.5">→ Shopify-ready metadata</text>
+  <text x="520" y="356" fill="#ca8a04" font-size="8.5">Images → structured catalogue</text>
+
+  <!-- ===== BOTTOM: CI/CD ===== -->
+  <rect x="30" y="510" width="690" height="90" rx="10" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="375" y="536" text-anchor="middle" fill="#1e293b" font-size="12" font-weight="600">CI/CD &amp; Quality Gates (GitHub Actions)</text>
+
+  <text x="60" y="558" fill="#475569" font-size="9.5">Ruff (15 rule sets)</text>
+  <text x="60" y="573" fill="#94a3b8" font-size="8.5">Lint + Format</text>
+
+  <text x="185" y="558" fill="#475569" font-size="9.5">mypy strict</text>
+  <text x="185" y="573" fill="#94a3b8" font-size="8.5">Type checking</text>
+
+  <text x="290" y="558" fill="#475569" font-size="9.5">pytest (70%+)</text>
+  <text x="290" y="573" fill="#94a3b8" font-size="8.5">Unit + Integration</text>
+
+  <text x="400" y="558" fill="#475569" font-size="9.5">Trivy + CodeQL</text>
+  <text x="400" y="573" fill="#94a3b8" font-size="8.5">Security scan</text>
+
+  <text x="520" y="558" fill="#475569" font-size="9.5">Smoke test</text>
+  <text x="520" y="573" fill="#94a3b8" font-size="8.5">Auto-rollback</text>
+
+  <text x="625" y="558" fill="#475569" font-size="9.5">Debt register</text>
+  <text x="625" y="573" fill="#94a3b8" font-size="8.5">105 items tracked</text>
+
+  <!-- ===== RIGHT SIDEBAR: Stats ===== -->
+  <rect x="780" y="85" width="290" height="515" rx="10" fill="#1e293b" filter="url(#shadow)"/>
+  <text x="925" y="116" text-anchor="middle" fill="#f8fafc" font-size="14" font-weight="600">By the Numbers</text>
+  <line x1="800" y1="130" x2="1050" y2="130" stroke="#475569" stroke-width="0.5"/>
+
+  <text x="925" y="162" text-anchor="middle" fill="#f59e0b" font-size="36" font-weight="700">5,200</text>
+  <text x="925" y="180" text-anchor="middle" fill="#94a3b8" font-size="11">lines of production code</text>
+
+  <text x="925" y="218" text-anchor="middle" fill="#f59e0b" font-size="36" font-weight="700">7,200+</text>
+  <text x="925" y="236" text-anchor="middle" fill="#94a3b8" font-size="11">lines of test code</text>
+
+  <text x="925" y="274" text-anchor="middle" fill="#f59e0b" font-size="36" font-weight="700">139</text>
+  <text x="925" y="292" text-anchor="middle" fill="#94a3b8" font-size="11">commits</text>
+
+  <text x="925" y="330" text-anchor="middle" fill="#f59e0b" font-size="36" font-weight="700">17</text>
+  <text x="925" y="348" text-anchor="middle" fill="#94a3b8" font-size="11">database migrations</text>
+
+  <text x="925" y="386" text-anchor="middle" fill="#f59e0b" font-size="36" font-weight="700">4</text>
+  <text x="925" y="404" text-anchor="middle" fill="#94a3b8" font-size="11">CI/CD workflows</text>
+
+  <text x="925" y="442" text-anchor="middle" fill="#f59e0b" font-size="36" font-weight="700">5</text>
+  <text x="925" y="460" text-anchor="middle" fill="#94a3b8" font-size="11">quality gates per commit</text>
+
+  <text x="925" y="498" text-anchor="middle" fill="#f59e0b" font-size="36" font-weight="700">105</text>
+  <text x="925" y="516" text-anchor="middle" fill="#94a3b8" font-size="11">debt items tracked</text>
+
+  <line x1="800" y1="536" x2="1050" y2="536" stroke="#475569" stroke-width="0.5"/>
+  <text x="925" y="560" text-anchor="middle" fill="#10b981" font-size="13" font-weight="600">Built in &lt; 2 weeks</text>
+  <text x="925" y="580" text-anchor="middle" fill="#6ee7b7" font-size="10">with AI-assisted development</text>
+
+  <!-- ===== ARROWS ===== -->
+  <!-- Client → API -->
+  <line x1="190" y1="120" x2="235" y2="120" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <!-- GDrive → API -->
+  <line x1="190" y1="200" x2="220" y2="200" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="220" y1="200" x2="220" y2="155" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="220" y1="155" x2="235" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- API → DB -->
+  <line x1="335" y1="280" x2="335" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <!-- API → R2 -->
+  <line x1="300" y1="280" x2="300" y2="420" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- API → Modal -->
+  <line x1="435" y1="160" x2="495" y2="160" stroke="#3b82f6" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrow-blue)"/>
+
+  <!-- Modal → DB (write embeddings) -->
+  <line x1="500" y1="245" x2="470" y2="245" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="470" y1="245" x2="470" y2="340" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="470" y1="340" x2="435" y2="340" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Clusters → Gemini -->
+  <line x1="610" y1="264" x2="610" y2="280" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Legend -->
+  <line x1="500" y1="390" x2="540" y2="390" stroke="#3b82f6" stroke-width="2" stroke-dasharray="6,3"/>
+  <text x="548" y="394" fill="#64748b" font-size="9">GPU job dispatch</text>
+  <line x1="500" y1="408" x2="540" y2="408" stroke="#64748b" stroke-width="1.5"/>
+  <text x="548" y="412" fill="#64748b" font-size="9">Data flow</text>
+</svg>

--- a/docs/images/pipeline-demo.svg
+++ b/docs/images/pipeline-demo.svg
@@ -1,0 +1,267 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 500" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <filter id="shadow" x="-4%" y="-4%" width="108%" height="112%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.1"/>
+    </filter>
+  </defs>
+
+  <style>
+    @keyframes fadeSlideIn {
+      0% { opacity: 0; transform: translateY(10px); }
+      100% { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes pulseGlow {
+      0%, 100% { opacity: 0.6; }
+      50% { opacity: 1; }
+    }
+    @keyframes drawLine {
+      0% { stroke-dashoffset: 100; }
+      100% { stroke-dashoffset: 0; }
+    }
+    @keyframes scatter {
+      0% { opacity: 0; }
+      100% { opacity: 1; }
+    }
+    @keyframes colorShift {
+      0% { fill: #94a3b8; }
+      100% { fill: #f59e0b; }
+    }
+
+    .step1 { animation: fadeSlideIn 0.6s ease-out 0.5s both; }
+    .step2 { animation: fadeSlideIn 0.6s ease-out 2s both; }
+    .step3 { animation: fadeSlideIn 0.6s ease-out 4s both; }
+    .step4 { animation: fadeSlideIn 0.6s ease-out 6s both; }
+    .step5 { animation: fadeSlideIn 0.6s ease-out 8s both; }
+
+    .arrow1 { animation: fadeSlideIn 0.4s ease-out 1.5s both; }
+    .arrow2 { animation: fadeSlideIn 0.4s ease-out 3.5s both; }
+    .arrow3 { animation: fadeSlideIn 0.4s ease-out 5.5s both; }
+    .arrow4 { animation: fadeSlideIn 0.4s ease-out 7.5s both; }
+
+    .dot-scatter { animation: scatter 0.3s ease-out both; }
+    .cluster-color { animation: colorShift 0.5s ease-out both; }
+  </style>
+
+  <!-- Background -->
+  <rect width="1000" height="500" rx="12" fill="#0f172a"/>
+
+  <!-- Title -->
+  <text x="500" y="38" text-anchor="middle" fill="#f8fafc" font-size="18" font-weight="600">PIC Pipeline — From Raw Images to Organised Catalogue</text>
+  <text x="500" y="56" text-anchor="middle" fill="#64748b" font-size="11">Fully automated · No manual tagging · No human in the loop</text>
+
+  <!-- ===== STEP 1: Raw Images ===== -->
+  <g class="step1">
+    <text x="100" y="100" text-anchor="middle" fill="#f59e0b" font-size="10" font-weight="700" letter-spacing="1.5">STEP 1</text>
+    <text x="100" y="116" text-anchor="middle" fill="#e2e8f0" font-size="13" font-weight="600">Raw Images</text>
+
+    <!-- Scattered image placeholders -->
+    <rect x="30" y="135" width="48" height="48" rx="4" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="34" y="139" width="40" height="28" rx="2" fill="#334155"/>
+    <circle cx="44" cy="150" r="4" fill="#f87171" opacity="0.7"/>
+    <polygon points="40,163 54,148 64,163" fill="#4ade80" opacity="0.5"/>
+
+    <rect x="85" y="145" width="48" height="48" rx="4" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="89" y="149" width="40" height="28" rx="2" fill="#334155"/>
+    <circle cx="99" cy="160" r="5" fill="#60a5fa" opacity="0.7"/>
+    <polygon points="95,173 109,158 119,173" fill="#a78bfa" opacity="0.5"/>
+
+    <rect x="42" y="195" width="48" height="48" rx="4" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="46" y="199" width="40" height="28" rx="2" fill="#334155"/>
+    <circle cx="56" cy="210" r="4" fill="#fbbf24" opacity="0.7"/>
+
+    <rect x="97" y="205" width="48" height="48" rx="4" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="101" y="209" width="40" height="28" rx="2" fill="#334155"/>
+    <polygon points="107,233 121,218 131,233" fill="#f87171" opacity="0.5"/>
+
+    <rect x="55" y="260" width="48" height="48" rx="4" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="59" y="264" width="40" height="28" rx="2" fill="#334155"/>
+    <circle cx="69" cy="275" r="5" fill="#34d399" opacity="0.7"/>
+
+    <text x="100" y="330" text-anchor="middle" fill="#64748b" font-size="10">50,000 untagged images</text>
+    <text x="100" y="344" text-anchor="middle" fill="#475569" font-size="9">No structure, no labels</text>
+  </g>
+
+  <!-- Arrow 1 -->
+  <g class="arrow1">
+    <line x1="160" y1="220" x2="195" y2="220" stroke="#f59e0b" stroke-width="2"/>
+    <polygon points="195,215 205,220 195,225" fill="#f59e0b"/>
+  </g>
+
+  <!-- ===== STEP 2: DINOv2 Embeddings ===== -->
+  <g class="step2">
+    <text x="300" y="100" text-anchor="middle" fill="#f59e0b" font-size="10" font-weight="700" letter-spacing="1.5">STEP 2</text>
+    <text x="300" y="116" text-anchor="middle" fill="#e2e8f0" font-size="13" font-weight="600">DINOv2 Embeddings</text>
+
+    <rect x="215" y="130" width="170" height="205" rx="8" fill="#1e293b" stroke="#7c3aed" stroke-width="1.5" stroke-opacity="0.5"/>
+
+    <!-- Neural network visualization -->
+    <text x="300" y="155" text-anchor="middle" fill="#a78bfa" font-size="10" font-weight="500">Vision Transformer</text>
+
+    <!-- Input layer dots -->
+    <circle cx="240" cy="180" r="4" fill="#f87171" opacity="0.8"/>
+    <circle cx="240" cy="200" r="4" fill="#60a5fa" opacity="0.8"/>
+    <circle cx="240" cy="220" r="4" fill="#4ade80" opacity="0.8"/>
+    <circle cx="240" cy="240" r="4" fill="#fbbf24" opacity="0.8"/>
+    <circle cx="240" cy="260" r="4" fill="#f472b6" opacity="0.8"/>
+
+    <!-- Hidden layer -->
+    <circle cx="290" cy="190" r="3.5" fill="#c4b5fd" opacity="0.6"/>
+    <circle cx="290" cy="210" r="3.5" fill="#c4b5fd" opacity="0.6"/>
+    <circle cx="290" cy="230" r="3.5" fill="#c4b5fd" opacity="0.6"/>
+    <circle cx="290" cy="250" r="3.5" fill="#c4b5fd" opacity="0.6"/>
+
+    <!-- Output layer -->
+    <circle cx="340" cy="195" r="3.5" fill="#a78bfa" opacity="0.8"/>
+    <circle cx="340" cy="215" r="3.5" fill="#a78bfa" opacity="0.8"/>
+    <circle cx="340" cy="235" r="3.5" fill="#a78bfa" opacity="0.8"/>
+
+    <!-- Connections (simplified) -->
+    <line x1="244" y1="180" x2="286" y2="190" stroke="#7c3aed" stroke-width="0.5" opacity="0.3"/>
+    <line x1="244" y1="200" x2="286" y2="210" stroke="#7c3aed" stroke-width="0.5" opacity="0.3"/>
+    <line x1="244" y1="220" x2="286" y2="230" stroke="#7c3aed" stroke-width="0.5" opacity="0.3"/>
+    <line x1="244" y1="240" x2="286" y2="250" stroke="#7c3aed" stroke-width="0.5" opacity="0.3"/>
+    <line x1="244" y1="200" x2="286" y2="190" stroke="#7c3aed" stroke-width="0.5" opacity="0.2"/>
+    <line x1="244" y1="220" x2="286" y2="210" stroke="#7c3aed" stroke-width="0.5" opacity="0.2"/>
+    <line x1="294" y1="190" x2="336" y2="195" stroke="#7c3aed" stroke-width="0.5" opacity="0.3"/>
+    <line x1="294" y1="210" x2="336" y2="215" stroke="#7c3aed" stroke-width="0.5" opacity="0.3"/>
+    <line x1="294" y1="230" x2="336" y2="235" stroke="#7c3aed" stroke-width="0.5" opacity="0.3"/>
+    <line x1="294" y1="250" x2="336" y2="235" stroke="#7c3aed" stroke-width="0.5" opacity="0.2"/>
+
+    <!-- Embedding vector -->
+    <rect x="235" y="285" width="130" height="30" rx="4" fill="#2d1b69" stroke="#7c3aed" stroke-width="1"/>
+    <text x="300" y="304" text-anchor="middle" fill="#c4b5fd" font-size="9" font-weight="500">[0.23, 0.87, ..., 0.41]</text>
+    <text x="300" y="330" text-anchor="middle" fill="#64748b" font-size="9.5">768 dimensions per image</text>
+    <text x="300" y="344" text-anchor="middle" fill="#475569" font-size="9">A100 GPU · Modal</text>
+  </g>
+
+  <!-- Arrow 2 -->
+  <g class="arrow2">
+    <line x1="395" y1="220" x2="430" y2="220" stroke="#f59e0b" stroke-width="2"/>
+    <polygon points="430,215 440,220 430,225" fill="#f59e0b"/>
+  </g>
+
+  <!-- ===== STEP 3: Clustering ===== -->
+  <g class="step3">
+    <text x="545" y="100" text-anchor="middle" fill="#f59e0b" font-size="10" font-weight="700" letter-spacing="1.5">STEP 3</text>
+    <text x="545" y="116" text-anchor="middle" fill="#e2e8f0" font-size="13" font-weight="600">Two-Level Clustering</text>
+
+    <rect x="450" y="130" width="190" height="205" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="1.5" stroke-opacity="0.5"/>
+
+    <!-- L1 Label -->
+    <text x="545" y="155" text-anchor="middle" fill="#6ee7b7" font-size="10" font-weight="600">L1: Near-Duplicate Detection</text>
+
+    <!-- Cluster 1 (reds) -->
+    <circle cx="485" cy="185" r="5" fill="#f87171"/>
+    <circle cx="496" cy="178" r="5" fill="#ef4444"/>
+    <circle cx="492" cy="192" r="5" fill="#fca5a5"/>
+    <ellipse cx="491" cy="185" rx="18" ry="14" fill="none" stroke="#f87171" stroke-width="1" stroke-dasharray="3,2" opacity="0.6"/>
+
+    <!-- Cluster 2 (blues) -->
+    <circle cx="545" cy="182" r="5" fill="#60a5fa"/>
+    <circle cx="556" cy="188" r="5" fill="#3b82f6"/>
+    <circle cx="540" cy="193" r="5" fill="#93c5fd"/>
+    <ellipse cx="547" cy="188" rx="18" ry="14" fill="none" stroke="#60a5fa" stroke-width="1" stroke-dasharray="3,2" opacity="0.6"/>
+
+    <!-- Cluster 3 (greens) -->
+    <circle cx="604" cy="180" r="5" fill="#4ade80"/>
+    <circle cx="615" cy="186" r="5" fill="#22c55e"/>
+    <ellipse cx="610" cy="183" rx="16" ry="12" fill="none" stroke="#4ade80" stroke-width="1" stroke-dasharray="3,2" opacity="0.6"/>
+
+    <!-- L2 Label -->
+    <text x="545" y="225" text-anchor="middle" fill="#6ee7b7" font-size="10" font-weight="600">L2: Semantic Similarity</text>
+
+    <!-- UMAP reduced space with bigger clusters -->
+    <circle cx="485" cy="260" r="7" fill="#f87171" opacity="0.8"/>
+    <circle cx="505" cy="250" r="7" fill="#fb923c" opacity="0.8"/>
+    <circle cx="495" cy="272" r="7" fill="#fbbf24" opacity="0.8"/>
+    <ellipse cx="495" cy="261" rx="25" ry="20" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,2" opacity="0.5"/>
+    <text x="495" y="292" text-anchor="middle" fill="#fbbf24" font-size="8">Bags</text>
+
+    <circle cx="570" cy="255" r="7" fill="#60a5fa" opacity="0.8"/>
+    <circle cx="590" cy="262" r="7" fill="#818cf8" opacity="0.8"/>
+    <circle cx="580" cy="275" r="7" fill="#a78bfa" opacity="0.8"/>
+    <ellipse cx="580" cy="264" rx="22" ry="18" fill="none" stroke="#818cf8" stroke-width="1.5" stroke-dasharray="4,2" opacity="0.5"/>
+    <text x="580" y="292" text-anchor="middle" fill="#818cf8" font-size="8">Shoes</text>
+
+    <text x="545" y="318" text-anchor="middle" fill="#64748b" font-size="9.5">HDBSCAN · UMAP</text>
+    <text x="545" y="332" text-anchor="middle" fill="#475569" font-size="9">Atomic transaction rollback</text>
+  </g>
+
+  <!-- Arrow 3 -->
+  <g class="arrow3">
+    <line x1="650" y1="220" x2="685" y2="220" stroke="#f59e0b" stroke-width="2"/>
+    <polygon points="685,215 695,220 685,225" fill="#f59e0b"/>
+  </g>
+
+  <!-- ===== STEP 4: Gemini Tagging ===== -->
+  <g class="step4">
+    <text x="800" y="100" text-anchor="middle" fill="#f59e0b" font-size="10" font-weight="700" letter-spacing="1.5">STEP 4</text>
+    <text x="800" y="116" text-anchor="middle" fill="#e2e8f0" font-size="13" font-weight="600">AI Tagging &amp; Output</text>
+
+    <rect x="700" y="130" width="195" height="205" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.5"/>
+
+    <text x="798" y="155" text-anchor="middle" fill="#fcd34d" font-size="10" font-weight="500">Google Gemini</text>
+
+    <!-- Product card 1 -->
+    <rect x="715" y="165" width="165" height="48" rx="5" fill="#1a1a2e" stroke="#334155" stroke-width="1"/>
+    <rect x="720" y="170" width="30" height="38" rx="3" fill="#334155"/>
+    <circle cx="735" cy="183" r="5" fill="#f87171" opacity="0.6"/>
+    <text x="760" y="183" fill="#e2e8f0" font-size="9" font-weight="500">Leather Crossbody Bag</text>
+    <text x="760" y="196" fill="#64748b" font-size="8">Tags: leather, crossbody, brown</text>
+    <text x="760" y="206" fill="#4ade80" font-size="7.5">Cluster #12 · 8 variants</text>
+
+    <!-- Product card 2 -->
+    <rect x="715" y="220" width="165" height="48" rx="5" fill="#1a1a2e" stroke="#334155" stroke-width="1"/>
+    <rect x="720" y="225" width="30" height="38" rx="3" fill="#334155"/>
+    <circle cx="735" cy="238" r="5" fill="#60a5fa" opacity="0.6"/>
+    <text x="760" y="238" fill="#e2e8f0" font-size="9" font-weight="500">Canvas Sneaker White</text>
+    <text x="760" y="251" fill="#64748b" font-size="8">Tags: canvas, sneaker, white</text>
+    <text x="760" y="261" fill="#4ade80" font-size="7.5">Cluster #7 · 12 variants</text>
+
+    <!-- Product card 3 -->
+    <rect x="715" y="275" width="165" height="48" rx="5" fill="#1a1a2e" stroke="#334155" stroke-width="1"/>
+    <rect x="720" y="280" width="30" height="38" rx="3" fill="#334155"/>
+    <circle cx="735" cy="293" r="5" fill="#4ade80" opacity="0.6"/>
+    <text x="760" y="293" fill="#e2e8f0" font-size="9" font-weight="500">Denim Tote Bag</text>
+    <text x="760" y="306" fill="#64748b" font-size="8">Tags: denim, tote, blue</text>
+    <text x="760" y="316" fill="#4ade80" font-size="7.5">Cluster #3 · 5 variants</text>
+
+    <text x="798" y="344" text-anchor="middle" fill="#64748b" font-size="9">Shopify-ready metadata</text>
+  </g>
+
+  <!-- ===== Bottom bar: Stack ===== -->
+  <g class="step5">
+    <rect x="30" y="380" width="940" height="100" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="500" y="404" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="600" letter-spacing="1">TECH STACK</text>
+
+    <!-- Stack items -->
+    <rect x="55" y="418" width="100" height="28" rx="14" fill="#1a1a2e" stroke="#3b82f6" stroke-width="1"/>
+    <text x="105" y="436" text-anchor="middle" fill="#60a5fa" font-size="10">Python 3.12</text>
+
+    <rect x="170" y="418" width="85" height="28" rx="14" fill="#1a1a2e" stroke="#10b981" stroke-width="1"/>
+    <text x="212" y="436" text-anchor="middle" fill="#34d399" font-size="10">FastAPI</text>
+
+    <rect x="270" y="418" width="105" height="28" rx="14" fill="#1a1a2e" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="322" y="436" text-anchor="middle" fill="#a78bfa" font-size="10">pgvector</text>
+
+    <rect x="390" y="418" width="85" height="28" rx="14" fill="#1a1a2e" stroke="#f59e0b" stroke-width="1"/>
+    <text x="432" y="436" text-anchor="middle" fill="#fbbf24" font-size="10">DINOv2</text>
+
+    <rect x="490" y="418" width="95" height="28" rx="14" fill="#1a1a2e" stroke="#ec4899" stroke-width="1"/>
+    <text x="537" y="436" text-anchor="middle" fill="#f472b6" font-size="10">HDBSCAN</text>
+
+    <rect x="600" y="418" width="72" height="28" rx="14" fill="#1a1a2e" stroke="#7c3aed" stroke-width="1"/>
+    <text x="636" y="436" text-anchor="middle" fill="#c4b5fd" font-size="10">Modal</text>
+
+    <rect x="687" y="418" width="82" height="28" rx="14" fill="#1a1a2e" stroke="#06b6d4" stroke-width="1"/>
+    <text x="728" y="436" text-anchor="middle" fill="#22d3ee" font-size="10">Railway</text>
+
+    <rect x="784" y="418" width="80" height="28" rx="14" fill="#1a1a2e" stroke="#f97316" stroke-width="1"/>
+    <text x="824" y="436" text-anchor="middle" fill="#fb923c" font-size="10">Gemini</text>
+
+    <rect x="879" y="418" width="72" height="28" rx="14" fill="#1a1a2e" stroke="#64748b" stroke-width="1"/>
+    <text x="915" y="436" text-anchor="middle" fill="#94a3b8" font-size="10">R2</text>
+
+    <text x="500" y="470" text-anchor="middle" fill="#475569" font-size="9">github.com/masa-57/PIC · Open Source · Built with Claude Code</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add SVG architecture diagram and animated pipeline demo to `docs/images/`
- Embed architecture diagram in README.md and `docs/deployment/architecture.md`
- Embed pipeline animation in README.md intro section

## Test plan
- [ ] Verify SVGs render correctly on GitHub README
- [ ] Verify relative image path works in `docs/deployment/architecture.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)