### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-03-15
 
 ### Added
 - Pluggable storage backend system with `StorageBackend` Protocol
@@ -43,4 +43,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker Compose for local development
 - CI/CD pipeline with GitHub Actions
 
+[0.2.0]: https://github.com/masa-57/pic/releases/tag/v0.2.0
 [0.1.0]: https://github.com/masa-57/pic/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pic"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hierarchical image clustering API for product catalog images"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0
- Update CHANGELOG.md with release date

## What's in v0.2.0
- **Pluggable storage backends** — S3, GCS, and local filesystem via `PIC_STORAGE_BACKEND`
- **URL-based image ingestion** — `POST /api/v1/images/ingest` with rate limiting, concurrent downloads, deduplication
- **Bug fixes** — shared rate limit storage (#17), configurable Google Drive OAuth scopes (#8)
- **Refactoring** — split `main.py` into focused modules

## Test plan
- [ ] CI passes (lint, unit tests, integration tests, container scan)
- [ ] Verify version in pyproject.toml is `0.2.0`
- [ ] Verify CHANGELOG.md has correct release date

🤖 Generated with [Claude Code](https://claude.com/claude-code)