### PR TITLE
fix: harden URL ingest and auth configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore URL-ingest Modal dispatch by exporting the `run_url_ingest` worker entrypoint
 - Track `auto_pipeline` follow-up work as a separate pipeline job instead of reusing the URL-ingest job
 - Refactor URL-ingest worker to avoid concurrent reuse of a single async DB session
+- Block SSRF-style URL-ingest targets across direct requests and redirect hops (#49)
+- Require explicit auth opt-out instead of silently disabling auth when `PIC_API_KEY` is unset (#50)
 
 ### Changed
 - Split `main.py` into `core/middleware.py`, `core/exception_handlers.py`, and `api/health.py`

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ PIC uses a two-level clustering approach:
 **Flows**:
 
 - **Ingestion**: Upload images to storage `images/` prefix -> compute pHash + DINOv2 embedding -> store vectors in PostgreSQL -> move to `processed/`
-- **URL Ingestion**: Submit image URLs via API -> download, deduplicate, and store with configurable concurrency. When `auto_pipeline=true`, PIC creates and tracks a separate pipeline job after ingestion succeeds.
+- **URL Ingestion**: Submit public image URLs via API -> download, deduplicate, and store with configurable concurrency. PIC rejects localhost, private-network, link-local, and redirected internal targets. When `auto_pipeline=true`, PIC creates and tracks a separate pipeline job after ingestion succeeds.
 - **Clustering**: Triggered via API or pipeline. L1 runs HDBSCAN on DINOv2 cosine distance; L2 runs UMAP + HDBSCAN on DINOv2 embeddings.
 - **Pipeline**: Single endpoint for n8n/automation -- discovers, deduplicates, ingests, and clusters in one call.
 - **Google Drive sync**: Watches a Drive folder, downloads new images, processes them, and syncs to storage.
 
 ## API Overview
 
-All endpoints are under `/api/v1/` and require an API key via `X-API-Key` header. For local development only, set `PIC_AUTH_DISABLED=true` to run without auth.
+All endpoints are under `/api/v1/` and require an API key via `X-API-Key` header by default. To run without auth, set `PIC_AUTH_DISABLED=true` explicitly. If `PIC_API_KEY` is unset and `PIC_AUTH_DISABLED=false`, protected endpoints return `503` so misconfigured non-production deployments do not silently run unauthenticated.
 
 | Endpoint Group | Description |
 |----------------|-------------|
@@ -98,7 +98,7 @@ All endpoints are under `/api/v1/` and require an API key via `X-API-Key` header
 | `/jobs` | List and inspect background job status |
 | `/health` | Basic and detailed health checks |
 
-`POST /api/v1/images/ingest` returns a URL-ingest job immediately. If `auto_pipeline=true`, the URL-ingest worker records the spawned pipeline job ID in the URL-ingest job result instead of reusing the original job record.
+`POST /api/v1/images/ingest` returns a URL-ingest job immediately. It accepts only public `http(s)` image URLs; localhost, RFC1918/link-local targets, and unsafe redirect hops are rejected. If `auto_pipeline=true`, the URL-ingest worker records the spawned pipeline job ID in the URL-ingest job result instead of reusing the original job record.
 
 ## Deployment
 
@@ -130,7 +130,7 @@ Copy `.env.example` to `.env` and configure. Key environment variables:
 | `PIC_LOCAL_STORAGE_BASE_URL` | Base URL for local file serving (e.g., `http://localhost:8000/files`) |
 | `PIC_ENV` | Runtime environment (`development`, `staging`, `production`, `test`) |
 | `PIC_API_KEY` | API authentication key (required in production unless explicitly disabled) |
-| `PIC_AUTH_DISABLED` | Explicitly allow unauthenticated mode (development only) |
+| `PIC_AUTH_DISABLED` | Explicitly allow unauthenticated mode when no `PIC_API_KEY` is set |
 | `PIC_SENTRY_DSN` | Sentry DSN for error tracking (optional) |
 | `PIC_RATE_LIMIT_STORAGE_URL` | Redis URI for shared rate limiting (optional, empty = in-memory) |
 | `PIC_GDRIVE_SERVICE_ACCOUNT_JSON` | Google Drive service account JSON (optional) |

--- a/docs/deployment/self-hosted.md
+++ b/docs/deployment/self-hosted.md
@@ -10,7 +10,7 @@ PIC's GPU workers are defined as Modal functions in `src/pic/modal_app.py`, but 
 - `src/pic/worker/cluster.py` -- Clustering logic
 - `src/pic/worker/pipeline.py` -- Pipeline orchestration
 - `src/pic/worker/gdrive_sync.py` -- Google Drive sync
-- `src/pic/worker/url_ingest.py` -- URL-based image ingestion (download, deduplicate, store)
+- `src/pic/worker/url_ingest.py` -- URL-based image ingestion (download, deduplicate, store; public `http(s)` targets only)
 
 ## Running Workers Directly
 
@@ -62,7 +62,7 @@ asyncio.run(run_cluster(job_id=1, params_json='{}'))
 "
 ```
 
-When `auto_pipeline=True` is used with `run_url_ingest`, the worker creates a separate `PIPELINE` job record rather than reusing the original URL-ingest job.
+When `auto_pipeline=True` is used with `run_url_ingest`, the worker creates a separate `PIPELINE` job record rather than reusing the original URL-ingest job. URL ingest rejects localhost, private-network, link-local, and redirected internal targets even in self-hosted deployments.
 
 ## Background Processing
 

--- a/src/pic/core/auth.py
+++ b/src/pic/core/auth.py
@@ -2,6 +2,7 @@
 
 import hmac
 import logging
+from enum import StrEnum
 
 from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
@@ -11,6 +12,12 @@ from pic.config import settings
 logger = logging.getLogger(__name__)
 
 _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+class AuthMode(StrEnum):
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+    MISCONFIGURED = "misconfigured"
 
 
 def _is_auth_disabled() -> bool:
@@ -23,23 +30,39 @@ def _env_name() -> str:
     return value.lower() if isinstance(value, str) else "development"
 
 
-_env = _env_name()
-_auth_disabled = _is_auth_disabled()
+def get_auth_mode() -> AuthMode:
+    if settings.api_key:
+        return AuthMode.ENABLED
+    if _is_auth_disabled():
+        return AuthMode.DISABLED
+    return AuthMode.MISCONFIGURED
 
-if not settings.api_key and (_auth_disabled or _env != "production"):
-    logger.warning(
-        "PIC_API_KEY not set. Authentication is disabled for non-production usage. "
-        "Set PIC_AUTH_DISABLED=true to acknowledge unauthenticated mode explicitly."
+
+def log_auth_mode() -> None:
+    """Log the effective authentication mode during startup."""
+    env = _env_name()
+    auth_mode = get_auth_mode()
+
+    if auth_mode == AuthMode.ENABLED:
+        logger.info("Authentication enabled with PIC_API_KEY (env=%s)", env)
+        return
+    if auth_mode == AuthMode.DISABLED:
+        logger.warning("Authentication disabled explicitly via PIC_AUTH_DISABLED=true (env=%s)", env)
+        return
+
+    logger.error(
+        "Authentication is not configured (env=%s): set PIC_API_KEY or PIC_AUTH_DISABLED=true. "
+        "Protected endpoints will return 503 until auth is configured.",
+        env,
     )
 
 
 async def verify_api_key(api_key: str | None = Security(_api_key_header)) -> None:
-    """Validate the API key. If no key is configured, auth is disabled (dev mode)."""
-    env = _env_name()
-    auth_disabled = _is_auth_disabled()
-    if not settings.api_key:
-        if auth_disabled or env != "production":
-            return
+    """Validate the API key using the explicit opt-out auth model."""
+    auth_mode = get_auth_mode()
+    if auth_mode == AuthMode.DISABLED:
+        return
+    if auth_mode == AuthMode.MISCONFIGURED:
         raise HTTPException(status_code=503, detail="Authentication is not configured")
     if not api_key or not hmac.compare_digest(api_key, settings.api_key):
         raise HTTPException(status_code=401, detail="Invalid or missing API key")

--- a/src/pic/main.py
+++ b/src/pic/main.py
@@ -14,7 +14,7 @@ from slowapi.errors import RateLimitExceeded
 from pic.api.health import router as health_router
 from pic.api.router import api_router, browser_router
 from pic.config import settings
-from pic.core.auth import verify_api_key
+from pic.core.auth import log_auth_mode, verify_api_key
 from pic.core.database import engine
 from pic.core.exception_handlers import (
     http_exception_handler,
@@ -46,6 +46,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.info("Sentry error tracking enabled")
     if settings.cors_origins == ["*"]:
         logger.warning("CORS is set to allow all origins — restrict cors_origins in production")
+    log_auth_mode()
     logger.info("PIC starting up")
     yield
     await engine.dispose()

--- a/src/pic/models/schemas.py
+++ b/src/pic/models/schemas.py
@@ -4,6 +4,7 @@ from typing import TypedDict
 from pydantic import BaseModel, Field, HttpUrl, field_validator
 
 from pic.models.db import JobStatus, JobType
+from pic.services.url_safety import validate_url_target
 
 
 class PaginationLinks(BaseModel):
@@ -227,6 +228,13 @@ class JobListOut(BaseModel):
 class UrlIngestRequest(BaseModel):
     urls: list[HttpUrl] = Field(..., min_length=1, max_length=100)
     auto_pipeline: bool = False
+
+    @field_validator("urls")
+    @classmethod
+    def validate_urls_are_public_targets(cls, urls: list[HttpUrl]) -> list[HttpUrl]:
+        for url in urls:
+            validate_url_target(str(url))
+        return urls
 
 
 class UrlIngestOut(BaseModel):

--- a/src/pic/services/url_safety.py
+++ b/src/pic/services/url_safety.py
@@ -1,0 +1,94 @@
+"""Utilities for validating externally supplied image URLs."""
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import SplitResult, urlsplit
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+_ALLOWED_URL_SCHEMES = {"http", "https"}
+_BLOCKED_HOSTNAMES = {
+    "localhost",
+    "localhost.localdomain",
+    "ip6-localhost",
+    "ip6-loopback",
+}
+
+
+def _normalize_host(host: str) -> str:
+    return host.strip().rstrip(".").lower()
+
+
+def _parse_ip_literal(host: str) -> IPAddress | None:
+    try:
+        return ipaddress.ip_address(host.split("%", 1)[0])
+    except ValueError:
+        return None
+
+
+def is_forbidden_ip_address(ip: IPAddress) -> bool:
+    """Return True when an IP address should never be fetched by URL ingest."""
+    return (
+        ip.is_loopback
+        or ip.is_private
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+        or getattr(ip, "is_site_local", False)
+    )
+
+
+def validate_url_target(url: str) -> SplitResult:
+    """Validate URL syntax and reject obviously unsafe local/private targets."""
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() not in _ALLOWED_URL_SCHEMES:
+        raise ValueError("Only http:// and https:// image URLs are allowed")
+    if parsed.hostname is None:
+        raise ValueError("URL must include a hostname")
+    if parsed.username or parsed.password:
+        raise ValueError("URLs with embedded credentials are not allowed")
+
+    hostname = _normalize_host(parsed.hostname)
+    if hostname in _BLOCKED_HOSTNAMES or hostname.endswith((".localhost", ".local")):
+        raise ValueError(f"URL host '{parsed.hostname}' is not allowed")
+
+    ip_address = _parse_ip_literal(hostname)
+    if ip_address is not None and is_forbidden_ip_address(ip_address):
+        raise ValueError(f"URL host '{parsed.hostname}' is not allowed")
+
+    return parsed
+
+
+async def resolve_public_ips(url: str) -> tuple[IPAddress, ...]:
+    """Resolve a URL hostname and reject any hop that targets non-public IPs."""
+    parsed = validate_url_target(url)
+    hostname = parsed.hostname
+    if hostname is None:
+        raise ValueError("URL must include a hostname")
+
+    try:
+        port = parsed.port or (443 if parsed.scheme.lower() == "https" else 80)
+    except ValueError as exc:
+        raise ValueError("URL port is invalid") from exc
+
+    try:
+        addr_info = await asyncio.get_running_loop().getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise ValueError(f"Could not resolve URL host '{hostname}'") from exc
+
+    resolved_ips: list[IPAddress] = []
+    for family, _, _, _, sockaddr in addr_info:
+        if family not in {socket.AF_INET, socket.AF_INET6}:
+            continue
+        resolved_ips.append(ipaddress.ip_address(sockaddr[0].split("%", 1)[0]))
+
+    if not resolved_ips:
+        raise ValueError(f"Could not resolve URL host '{hostname}'")
+
+    forbidden_ips = sorted({str(ip) for ip in resolved_ips if is_forbidden_ip_address(ip)})
+    if forbidden_ips:
+        raise ValueError(f"URL host '{hostname}' resolves to a non-public address: {', '.join(forbidden_ips)}")
+
+    return tuple(resolved_ips)

--- a/src/pic/worker/url_ingest.py
+++ b/src/pic/worker/url_ingest.py
@@ -7,17 +7,19 @@ import os
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pic.config import settings
+from pic.services.url_safety import resolve_public_ips, validate_url_target
 
 logger = logging.getLogger(__name__)
 
 _URL_DOWNLOAD_TIMEOUT = 30  # seconds per URL
+_MAX_REDIRECTS = 5
 
 
 @dataclass(frozen=True)
@@ -30,24 +32,41 @@ class DownloadResult:
 async def download_from_url(url: str) -> bytes:
     """Download an image from a URL with validation."""
     max_bytes = settings.max_image_download_mb * 1024 * 1024
+    current_url = url
+    validate_url_target(current_url)
+    await resolve_public_ips(current_url)
 
-    async with httpx.AsyncClient(follow_redirects=True, timeout=_URL_DOWNLOAD_TIMEOUT) as client:
-        response = await client.get(url)
-        response.raise_for_status()
+    async with httpx.AsyncClient(follow_redirects=False, timeout=_URL_DOWNLOAD_TIMEOUT, trust_env=False) as client:
+        for redirect_count in range(_MAX_REDIRECTS + 1):
+            response = await client.get(current_url)
 
-        content_type = response.headers.get("content-type", "")
-        if not content_type.startswith("image/"):
-            raise ValueError(f"URL content is not an image (content-type: {content_type})")
+            if 300 <= response.status_code < 400:
+                redirect_location = response.headers.get("location")
+                if not redirect_location:
+                    raise ValueError("Redirect response missing Location header")
+                if redirect_count >= _MAX_REDIRECTS:
+                    raise ValueError(f"URL exceeded redirect limit ({_MAX_REDIRECTS})")
+                current_url = urljoin(current_url, redirect_location)
+                validate_url_target(current_url)
+                await resolve_public_ips(current_url)
+                continue
 
-        content_length = response.headers.get("content-length")
-        if content_length and int(content_length) > max_bytes:
-            raise ValueError(f"Image exceeds size limit ({int(content_length)} > {max_bytes} bytes)")
+            response.raise_for_status()
+            content_type = response.headers.get("content-type", "")
+            if not content_type.startswith("image/"):
+                raise ValueError(f"URL content is not an image (content-type: {content_type})")
 
-        data = response.content
-        if len(data) > max_bytes:
-            raise ValueError(f"Image exceeds size limit ({len(data)} > {max_bytes} bytes)")
+            content_length = response.headers.get("content-length")
+            if content_length and int(content_length) > max_bytes:
+                raise ValueError(f"Image exceeds size limit ({int(content_length)} > {max_bytes} bytes)")
 
-        return data
+            data = response.content
+            if len(data) > max_bytes:
+                raise ValueError(f"Image exceeds size limit ({len(data)} > {max_bytes} bytes)")
+
+            return data
+
+    raise ValueError(f"URL exceeded redirect limit ({_MAX_REDIRECTS})")
 
 
 def _filename_from_url(url: str) -> str:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,6 +71,7 @@ async def client(db):
 
     with patch("pic.core.auth.settings") as mock_auth:
         mock_auth.api_key = ""
+        mock_auth.auth_disabled = True
         from pic.api.deps import get_db
         from pic.main import app
 

--- a/tests/integration/test_images_url_ingest.py
+++ b/tests/integration/test_images_url_ingest.py
@@ -45,6 +45,20 @@ class TestUrlIngestEndpoint:
         )
         assert response.status_code == 422
 
+    async def test_ingest_rejects_localhost_targets(self, client):
+        response = await client.post(
+            "/api/v1/images/ingest",
+            json={"urls": ["http://localhost/photo.jpg"]},
+        )
+        assert response.status_code == 422
+
+    async def test_ingest_rejects_private_ip_targets(self, client):
+        response = await client.post(
+            "/api/v1/images/ingest",
+            json={"urls": ["http://127.0.0.1/photo.jpg"]},
+        )
+        assert response.status_code == 422
+
     async def test_ingest_multiple_urls(self, client):
         """POST /images/ingest with multiple valid URLs."""
         with patch(

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -73,6 +73,7 @@ def client():
     """Create a test client with mocked DB dependency and auth disabled."""
     with patch("pic.core.auth.settings") as mock_auth_settings:
         mock_auth_settings.api_key = ""  # Disable auth for most tests
+        mock_auth_settings.auth_disabled = True
         from pic.main import app
 
         with TestClient(app) as c:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,5 +1,6 @@
 """Unit tests for API key authentication."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -48,16 +49,40 @@ class TestVerifyApiKey:
 
     @pytest.mark.asyncio
     async def test_no_configured_key_skips_auth(self):
-        """When api_key is empty, all requests pass (dev mode)."""
+        """Explicit auth disable should bypass API-key checks."""
+        with patch("pic.core.auth.settings") as mock_settings:
+            mock_settings.api_key = ""
+            mock_settings.env = "development"
+            mock_settings.auth_disabled = True
+            from pic.core.auth import verify_api_key
+
+            await verify_api_key(None)
+            await verify_api_key("")
+            await verify_api_key("any-random-key")
+
+    @pytest.mark.asyncio
+    async def test_no_key_in_development_raises_503_without_explicit_disable(self):
         with patch("pic.core.auth.settings") as mock_settings:
             mock_settings.api_key = ""
             mock_settings.env = "development"
             mock_settings.auth_disabled = False
             from pic.core.auth import verify_api_key
 
-            await verify_api_key(None)
-            await verify_api_key("")
-            await verify_api_key("any-random-key")
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_api_key(None)
+            assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_no_key_in_staging_raises_503_without_explicit_disable(self):
+        with patch("pic.core.auth.settings") as mock_settings:
+            mock_settings.api_key = ""
+            mock_settings.env = "staging"
+            mock_settings.auth_disabled = False
+            from pic.core.auth import verify_api_key
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_api_key(None)
+            assert exc_info.value.status_code == 503
 
     @pytest.mark.asyncio
     async def test_no_key_in_production_raises_503(self):
@@ -85,3 +110,42 @@ class TestVerifyApiKey:
 
             await verify_api_key("test-key")
             mock_compare.assert_called_once_with("test-key", "test-key")
+
+
+@pytest.mark.unit
+class TestAuthModeLogging:
+    def test_log_auth_mode_enabled(self, caplog):
+        with patch("pic.core.auth.settings") as mock_settings:
+            mock_settings.api_key = "secret"
+            mock_settings.env = "staging"
+            mock_settings.auth_disabled = False
+            from pic.core.auth import log_auth_mode
+
+            with caplog.at_level(logging.INFO):
+                log_auth_mode()
+
+        assert "Authentication enabled with PIC_API_KEY" in caplog.text
+
+    def test_log_auth_mode_explicitly_disabled(self, caplog):
+        with patch("pic.core.auth.settings") as mock_settings:
+            mock_settings.api_key = ""
+            mock_settings.env = "development"
+            mock_settings.auth_disabled = True
+            from pic.core.auth import log_auth_mode
+
+            with caplog.at_level(logging.WARNING):
+                log_auth_mode()
+
+        assert "Authentication disabled explicitly" in caplog.text
+
+    def test_log_auth_mode_misconfigured(self, caplog):
+        with patch("pic.core.auth.settings") as mock_settings:
+            mock_settings.api_key = ""
+            mock_settings.env = "staging"
+            mock_settings.auth_disabled = False
+            from pic.core.auth import log_auth_mode
+
+            with caplog.at_level(logging.ERROR):
+                log_auth_mode()
+
+        assert "Protected endpoints will return 503" in caplog.text

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -108,6 +108,14 @@ class TestAuthConfiguration:
         with pytest.raises(ValueError, match="PIC_API_KEY is required when PIC_ENV=production"):
             Settings(env="production", api_key="", auth_disabled=False)
 
+    def test_non_production_can_start_without_api_key(self):
+        from pic.config import Settings
+
+        s = Settings(env="staging", api_key="", auth_disabled=False)
+        assert s.env == "staging"
+        assert s.api_key == ""
+        assert s.auth_disabled is False
+
     def test_production_allows_explicit_auth_disable(self):
         from pic.config import Settings
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -13,6 +13,7 @@ def client():
     """Create a test client with auth disabled."""
     with patch("pic.core.auth.settings") as mock_auth_settings:
         mock_auth_settings.api_key = ""
+        mock_auth_settings.auth_disabled = True
         from pic.main import app
 
         with TestClient(app) as c:

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -11,6 +11,7 @@ def client():
     """Create a test client with auth disabled."""
     with patch("pic.core.auth.settings") as mock_auth_settings:
         mock_auth_settings.api_key = ""
+        mock_auth_settings.auth_disabled = True
         from pic.main import app
 
         with TestClient(app) as c:

--- a/tests/unit/test_url_ingest.py
+++ b/tests/unit/test_url_ingest.py
@@ -24,9 +24,11 @@ class TestDownloadFromUrl:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client.get = AsyncMock(return_value=mock_response)
             mock_client_cls.return_value = mock_client
+            with patch("pic.worker.url_ingest.resolve_public_ips", new_callable=AsyncMock) as mock_resolve:
+                result = await download_from_url("https://example.com/photo.jpg")
 
-            result = await download_from_url("https://example.com/photo.jpg")
             assert result == b"fake-image-data"
+            mock_resolve.assert_awaited_once_with("https://example.com/photo.jpg")
 
     @pytest.mark.asyncio
     async def test_rejects_non_image_content_type(self):
@@ -43,8 +45,10 @@ class TestDownloadFromUrl:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client.get = AsyncMock(return_value=mock_response)
             mock_client_cls.return_value = mock_client
-
-            with pytest.raises(ValueError, match="not an image"):
+            with (
+                patch("pic.worker.url_ingest.resolve_public_ips", new_callable=AsyncMock),
+                pytest.raises(ValueError, match="not an image"),
+            ):
                 await download_from_url("https://example.com/page.html")
 
     @pytest.mark.asyncio
@@ -62,9 +66,50 @@ class TestDownloadFromUrl:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client.get = AsyncMock(return_value=mock_response)
             mock_client_cls.return_value = mock_client
-
-            with pytest.raises(ValueError, match="exceeds size limit"):
+            with (
+                patch("pic.worker.url_ingest.resolve_public_ips", new_callable=AsyncMock),
+                pytest.raises(ValueError, match="exceeds size limit"),
+            ):
                 await download_from_url("https://example.com/huge.jpg")
+
+    @pytest.mark.asyncio
+    async def test_rejects_private_ip_literal_without_fetching(self):
+        from pic.worker.url_ingest import download_from_url
+
+        with (
+            patch("pic.worker.url_ingest.httpx.AsyncClient") as mock_client_cls,
+            pytest.raises(ValueError, match="not allowed"),
+        ):
+            await download_from_url("http://127.0.0.1/private.jpg")
+
+        mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_redirect_to_private_host(self):
+        from pic.worker.url_ingest import download_from_url
+
+        redirect_response = MagicMock()
+        redirect_response.status_code = 302
+        redirect_response.headers = {"location": "http://127.0.0.1/private.jpg"}
+
+        with patch("pic.worker.url_ingest.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=redirect_response)
+            mock_client_cls.return_value = mock_client
+
+            with (
+                patch(
+                    "pic.worker.url_ingest.resolve_public_ips",
+                    new_callable=AsyncMock,
+                    side_effect=[("93.184.216.34",), ValueError("URL host '127.0.0.1' is not allowed")],
+                ),
+                pytest.raises(ValueError, match="not allowed"),
+            ):
+                await download_from_url("https://example.com/photo.jpg")
+
+        assert mock_client.get.await_count == 1
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -1375,7 +1375,7 @@ wheels = [
 
 [[package]]
 name = "pic"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2410,6 +2410,7 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
     { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
     { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
     { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },


### PR DESCRIPTION
## Summary
- block SSRF-style URL ingest targets at validation and download time, including redirect hops and non-public DNS resolutions
- require explicit auth opt-out when PIC_API_KEY is unset and log the effective auth mode at startup
- update unit coverage, URL-ingest endpoint tests, and deployment/docs text to match the new security behavior

## Testing
- uv run ruff check src/ tests/ scripts/
- uv run ruff format --check src/ tests/ scripts/
- uv run mypy src/pic/
- uv run pytest -m unit
- uv run pip-audit
- uv lock --check

## Notes
- Added URL-ingest integration test coverage for blocked localhost/private targets, but did not run integration tests in this shell because Docker/PostgreSQL was unavailable.

Fixes #49
Fixes #50