### PR TITLE
fix: reconcile metrics and runtime docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ A `Makefile` provides shortcuts: `make dev`, `make test`, `make test-all`, `make
 
 **Product flow** (post-clustering): After clustering, L1 groups become product candidates. `GET /api/v1/products/candidates` lists unprocessed L1 groups. AI (via n8n) generates title/description/tags, then `POST /api/v1/products` creates a product from an L1 group, linking all member images. Full CRUD on `/api/v1/products`.
 
-**Auth**: API key via `X-API-Key` header on all `/api/v1/*` routes. Set `PIC_API_KEY` env var; if empty/unset, auth is disabled (dev mode). Uses timing-safe comparison.
+**Auth**: API key via `X-API-Key` header on all `/api/v1/*` routes. Set `PIC_API_KEY` for protected mode; if it is unset, routes return 503 unless `PIC_AUTH_DISABLED=true` explicitly opts into unauthenticated mode. Uses timing-safe comparison.
 
 **Health checks**: `GET /health` (basic) and `GET /health/detailed` (DB connectivity + recent job failures).
 
@@ -115,7 +115,7 @@ A `Makefile` provides shortcuts: `make dev`, `make test`, `make test-all`, `make
 
 Copy `.env.example` to `.env` and fill in values. Key vars: `PIC_DATABASE_URL`, `PIC_S3_BUCKET`, `PIC_S3_ENDPOINT_URL`, `PIC_S3_ACCESS_KEY_ID`, `PIC_S3_SECRET_ACCESS_KEY`.
 
-Optional observability: `PIC_SENTRY_DSN` (error tracking, empty = disabled). Prometheus metrics are exposed automatically via `prometheus-fastapi-instrumentator`.
+Optional observability: `PIC_SENTRY_DSN` (error tracking, empty = disabled). Prometheus metrics are exposed at `/metrics` via `prometheus-fastapi-instrumentator`; that endpoint uses the same auth dependency unless `PIC_AUTH_DISABLED=true`.
 
 Optional Google Drive sync: `PIC_GDRIVE_SERVICE_ACCOUNT_JSON` (service account JSON string), `PIC_GDRIVE_FOLDER_ID` (folder to watch). Both must be set to enable GDrive sync. OAuth scopes configurable via `PIC_GDRIVE_SCOPES` (default: `["https://www.googleapis.com/auth/drive"]`; use `drive.readonly` if move-to-processed is not needed).
 
@@ -162,7 +162,7 @@ For Modal: run `modal setup` to authenticate, then `modal deploy src/pic/modal_a
 - `images.content_hash` column (SHA256) has a unique index -- duplicate content is rejected
 - HNSW vector index exists on `embedding` column -- fast k-NN search, no need for brute-force scans
 - Structured JSON logging in production -- request IDs tracked via `X-Request-ID` header
-- `Product.tags` is stored as JSON text (not a native JSON column) -- serialize with `json.dumps()`, deserialize with `json.loads()`
+- `Product.tags` is stored as native PostgreSQL JSONB -- treat it as structured JSON, not serialized text
 - GDrive sync worker shares the same advisory lock (`0x50494301`) as pipeline -- they cannot run concurrently
 - Modal cron `check_gdrive_for_new_files` runs every 15 min on a lightweight CPU image (no ML deps)
 - GDrive sync requires both `PIC_GDRIVE_SERVICE_ACCOUNT_JSON` and `PIC_GDRIVE_FOLDER_ID` -- endpoint returns 400 if missing

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ PIC uses a two-level clustering approach:
 
 All endpoints are under `/api/v1/` and require an API key via `X-API-Key` header by default. To run without auth, set `PIC_AUTH_DISABLED=true` explicitly. If `PIC_API_KEY` is unset and `PIC_AUTH_DISABLED=false`, protected endpoints return `503` so misconfigured non-production deployments do not silently run unauthenticated.
 
+The Prometheus scrape target is `GET /metrics` at the app root. It uses the same auth dependency as the API unless you explicitly run with `PIC_AUTH_DISABLED=true`.
+
 | Endpoint Group | Description |
 |----------------|-------------|
 | `/images` | Upload, list, get, delete images; ingest from URLs |
@@ -110,6 +112,7 @@ PIC is designed for deployment with:
 - **Object storage**: S3-compatible (Cloudflare R2, MinIO, AWS S3), Google Cloud Storage, or local filesystem
 
 See `docs/deployment/` for detailed deployment guides.
+See [monitoring setup](docs/operations/monitoring-setup.md) for Prometheus/Grafana notes, including the authenticated `/metrics` scrape path.
 
 ## Configuration
 

--- a/docs/deployment/architecture.md
+++ b/docs/deployment/architecture.md
@@ -104,12 +104,12 @@ All configuration is via environment variables with the `PIC_` prefix.
 |----------|----------|-------------|
 | `PIC_DATABASE_URL` | Yes | PostgreSQL connection string (asyncpg) |
 | `PIC_API_KEY` | Production | API authentication key |
+| `PIC_AUTH_DISABLED` | No | Explicit opt-out for unauthenticated mode |
 | `PIC_STORAGE_BACKEND` | No | Storage backend: `s3` (default), `gcs`, `local` |
 | `PIC_S3_ENDPOINT_URL` | S3 only | S3-compatible endpoint |
 | `PIC_S3_ACCESS_KEY_ID` | S3 only | S3 access key |
 | `PIC_S3_SECRET_ACCESS_KEY` | S3 only | S3 secret key |
 | `PIC_S3_BUCKET` | S3 only | Bucket name (default: `pic-images`) |
-| `PIC_S3_REGION` | No | Region (default: `auto` for R2) |
 | `PIC_GCS_BUCKET` | GCS only | GCS bucket name |
 | `PIC_GCS_PROJECT_ID` | GCS only | GCS project ID |
 | `PIC_GCS_CREDENTIALS_JSON` | GCS only | Service account JSON |
@@ -117,9 +117,10 @@ All configuration is via environment variables with the `PIC_` prefix.
 | `PIC_LOCAL_STORAGE_BASE_URL` | Local only | Base URL for file serving |
 | `PIC_CORS_ORIGINS` | No | Allowed CORS origins (comma-separated) |
 | `PIC_LOG_LEVEL` | No | Log level (default: `INFO`) |
-| `PIC_LOG_FORMAT` | No | `json` for structured logging |
-| `PIC_MODAL_ENVIRONMENT` | No | Modal environment name |
+| `PIC_SENTRY_DSN` | No | Sentry DSN for error tracking |
+| `PIC_RATE_LIMIT_STORAGE_URL` | No | Shared Redis backend for rate limiting |
 | `PIC_GDRIVE_FOLDER_ID` | No | Google Drive folder for sync |
 | `PIC_GDRIVE_SERVICE_ACCOUNT_JSON` | No | GDrive service account credentials |
+| `PIC_GDRIVE_SCOPES` | No | OAuth scopes for Google Drive sync |
 
 See `.env.example` for a complete reference.

--- a/docs/deployment/modal-setup.md
+++ b/docs/deployment/modal-setup.md
@@ -6,7 +6,7 @@
 
 - Modal account ([modal.com](https://modal.com))
 - Modal CLI installed: `pip install modal`
-- Modal token configured: `modal token new`
+- Modal authentication configured: `modal setup`
 
 ## Configure Secrets
 
@@ -19,7 +19,6 @@ modal secret create pic-env \
   PIC_S3_ACCESS_KEY_ID="your-access-key" \
   PIC_S3_SECRET_ACCESS_KEY="your-secret-key" \
   PIC_S3_BUCKET="pic-images" \
-  PIC_S3_REGION="auto" \
   PIC_GDRIVE_FOLDER_ID="your-folder-id" \
   PIC_GDRIVE_SERVICE_ACCOUNT_JSON='{"type":"service_account",...}'
 ```
@@ -31,11 +30,11 @@ modal secret create pic-env \
 modal deploy src/pic/modal_app.py
 
 # Deploy with a specific tag (used in CI/CD)
-modal deploy src/pic/modal_app.py --tag "v0.1.0"
+modal deploy src/pic/modal_app.py --tag "v0.2.0"
 ```
 
 This deploys:
-- `run_ingest` -- Processes uploaded images (download, hash, store metadata)
+- `run_ingest` -- Processes uploaded images (hash + DINOv2 embedding, then moves objects to `processed/`)
 - `run_cluster` -- Runs hierarchical clustering (L1 HDBSCAN on cosine distance + L2 UMAP/HDBSCAN on DINOv2 embeddings)
 - `run_pipeline` -- End-to-end pipeline (discover, dedup, ingest, cluster)
 - `run_url_ingest` -- Downloads images from URLs, stores them, and can queue a separate pipeline job
@@ -50,7 +49,7 @@ The Modal app includes a scheduled function for Google Drive sync. After deployi
 modal app list  # Should show "pic" app
 ```
 
-The GDrive sync cron runs on a schedule defined in `modal_app.py`. It only triggers if `PIC_GDRIVE_FOLDER_ID` is configured.
+The GDrive sync cron runs on a schedule defined in `modal_app.py`. It only triggers when both `PIC_GDRIVE_FOLDER_ID` and `PIC_GDRIVE_SERVICE_ACCOUNT_JSON` are configured.
 
 ## CI/CD Integration
 

--- a/docs/deployment/self-hosted.md
+++ b/docs/deployment/self-hosted.md
@@ -58,7 +58,7 @@ uv run fastapi run src/pic/main.py --host 0.0.0.0 --port 8000
 uv run python -c "
 import asyncio
 from pic.worker.cluster import run_cluster
-asyncio.run(run_cluster(job_id=1, params_json='{}'))
+asyncio.run(run_cluster(job_id='job-id-123', params_json='{}'))
 "
 ```
 
@@ -77,6 +77,5 @@ For production without Modal, consider:
 For GPU-accelerated embedding generation, ensure:
 - NVIDIA drivers and CUDA toolkit installed
 - PyTorch installed with CUDA support: `pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121`
-- The `PIC_DEVICE` environment variable is set (defaults to auto-detect)
 
 Workers will automatically use GPU if available via PyTorch's device detection.

--- a/docs/gdrive-setup-guide.md
+++ b/docs/gdrive-setup-guide.md
@@ -32,7 +32,7 @@ Set the following in your deployment environment:
 
 | Variable | Value |
 |---|---|
-| `PIC_GDRIVE_CREDENTIALS_JSON` | Contents of the JSON key file from step 1.4 |
+| `PIC_GDRIVE_SERVICE_ACCOUNT_JSON` | Contents of the JSON key file from step 1.4 |
 | `PIC_GDRIVE_FOLDER_ID` | Folder ID copied from the URL in step 2.3 |
 
 > **Security:** The JSON key file contains sensitive credentials. Never commit it to version control or share it over unencrypted channels.

--- a/docs/operations/monitoring-setup.md
+++ b/docs/operations/monitoring-setup.md
@@ -4,13 +4,19 @@ This document describes how to monitor the PIC API using Prometheus and Grafana.
 
 ## Metrics Endpoint
 
-The PIC API exposes a `/metrics` endpoint via `prometheus-fastapi-instrumentator`.
+The PIC API exposes `GET /metrics` via `prometheus-fastapi-instrumentator`.
 This endpoint returns metrics in Prometheus text exposition format.
+
+`/metrics` is not under `/api/v1`, but it is still protected by the same API-key dependency as the application. In practice:
+
+- If `PIC_API_KEY` is set, scrapers must send `X-API-Key: <value>`
+- If `PIC_API_KEY` is unset and `PIC_AUTH_DISABLED=false`, `/metrics` returns `503`
+- If `PIC_AUTH_DISABLED=true`, `/metrics` is intentionally unauthenticated. Use that only for local development or an internal-only scrape target
 
 To verify locally:
 
 ```bash
-curl http://localhost:8000/metrics
+curl -H "X-API-Key: ${PIC_API_KEY}" http://localhost:8000/metrics
 ```
 
 ## Key Metrics
@@ -19,17 +25,18 @@ curl http://localhost:8000/metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `http_requests_total` | Counter | method, endpoint, status | Total HTTP requests processed |
-| `http_request_duration_seconds` | Histogram | method, endpoint | Request latency distribution |
-| `http_requests_total` (instrumentator) | Counter | method, handler, status | Auto-instrumented request count |
-| `http_request_duration_seconds` (instrumentator) | Histogram | method, handler | Auto-instrumented latency |
+| `http_requests_total` | Counter | method, handler, status | Auto-instrumented request count |
+| `http_request_duration_seconds` | Histogram | method, handler | Low-cardinality latency histogram by handler |
+| `http_request_duration_highr_seconds` | Histogram | none | High-resolution latency histogram for global percentile alerts |
+| `http_request_size_bytes` | Summary | handler | Observed request body sizes |
+| `http_response_size_bytes` | Summary | handler | Observed response sizes |
 
 ### Job Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `jobs_created_total` | Counter | type | Background jobs created (INGEST, CLUSTER_FULL, PIPELINE, etc.) |
-| `jobs_completed_total` | Counter | type, status | Background jobs completed (COMPLETED, FAILED) |
+| `jobs_created_total` | Counter | type | PIC custom counter for created background jobs (`CLUSTER_FULL`, `PIPELINE`, `URL_INGEST`, `GDRIVE_SYNC`) |
+| `jobs_completed_total` | Counter | type, status | PIC custom counter for terminal job outcomes (`COMPLETED`, `FAILED`) |
 
 ### Database Pool Metrics
 
@@ -43,20 +50,25 @@ curl http://localhost:8000/metrics
 
 ### Critical
 
-- `http_request_duration_seconds` p99 > 5s for 5 minutes
+- `http_request_duration_highr_seconds` p99 > 5s for 5 minutes
 - `http_requests_total` with status 5xx rate > 1% of total for 5 minutes
 - `db_pool_checked_out` equals pool size for 2 minutes (pool exhaustion)
 - `/health` endpoint returning non-200 for 1 minute
 
 ### Warning
 
-- `http_request_duration_seconds` p95 > 2s for 10 minutes
+- `http_request_duration_highr_seconds` p95 > 2s for 10 minutes
 - `jobs_completed_total{status="FAILED"}` rate increasing for 15 minutes
 - `db_pool_overflow` > 0 for 5 minutes (pool under pressure)
 
 ## Prometheus Scrape Configuration
 
-Add the following to your `prometheus.yml`:
+Prometheus cannot scrape the default PIC endpoint anonymously. Use one of these patterns:
+
+1. Scrape an internal-only PIC deployment where `PIC_AUTH_DISABLED=true` was set deliberately.
+2. Scrape a reverse proxy or sidecar that injects the required `X-API-Key` header before forwarding to PIC.
+
+Example scrape config for an internal-only target with explicit auth disable:
 
 ```yaml
 scrape_configs:
@@ -69,8 +81,7 @@ scrape_configs:
           environment: "production"
 ```
 
-For Railway deployments, you may need to use a service discovery mechanism
-or configure an external Prometheus instance to reach the Railway public URL.
+If you keep `PIC_API_KEY` enabled, point Prometheus at a proxy endpoint that handles header injection. Do not assume Railway or another public ingress can scrape `/metrics` directly without credentials.
 
 ## Grafana Dashboard Configuration
 
@@ -83,15 +94,16 @@ or configure an external Prometheus instance to reach the Railway public URL.
 
 **Row: HTTP Overview**
 
-- Request rate: `rate(http_requests_total[5m])`
-- Error rate: `rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m])`
-- Latency p50/p95/p99: `histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))`
+- Request rate: `sum(rate(http_requests_total[5m]))`
+- Error rate: `sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))`
+- Latency p50/p95/p99: `histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le))`
+- Handler latency p95: `histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (handler, le))`
 
 **Row: Background Jobs**
 
-- Jobs created rate: `rate(jobs_created_total[5m])` by type
-- Jobs failed rate: `rate(jobs_completed_total{status="FAILED"}[5m])` by type
-- Job success ratio: `rate(jobs_completed_total{status="COMPLETED"}[5m]) / rate(jobs_completed_total[5m])`
+- Jobs created rate: `sum(rate(jobs_created_total[5m])) by (type)`
+- Jobs failed rate: `sum(rate(jobs_completed_total{status="FAILED"}[5m])) by (type)`
+- Job success ratio: `sum(rate(jobs_completed_total{status="COMPLETED"}[5m])) by (type) / sum(rate(jobs_completed_total[5m])) by (type)`
 
 **Row: Database Pool**
 

--- a/src/pic/api/deps.py
+++ b/src/pic/api/deps.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from pic.config import settings
 from pic.core.database import async_session
+from pic.core.metrics import record_job_created, record_job_finished
 from pic.models.db import Job, JobStatus, JobType
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,7 @@ async def create_and_dispatch_job(
     db.add(job)
     await db.commit()
     await db.refresh(job)
+    record_job_created(job_type)
 
     try:
         modal_call_id = await dispatch_fn(job_id, params)
@@ -73,6 +75,7 @@ async def create_and_dispatch_job(
             update(Job).where(Job.id == job_id).values(status=JobStatus.FAILED, error="Failed to dispatch job to Modal")
         )
         await db.commit()
+        record_job_finished(job_type, JobStatus.FAILED)
         raise HTTPException(status_code=503, detail="Failed to dispatch job to compute backend") from None
 
     # Store Modal call ID for failure monitoring

--- a/src/pic/config.py
+++ b/src/pic/config.py
@@ -55,8 +55,8 @@ class Settings(BaseSettings):
     hnsw_ef_search: int = 100  # HNSW ef_search for recall/speed trade-off (higher = better recall)
 
     # API
-    api_key: str = ""  # If empty, auth is disabled (dev mode)
-    auth_disabled: bool = False  # Explicit acknowledgment for unauthenticated development mode
+    api_key: str = ""  # Protected routes require this unless auth is explicitly disabled
+    auth_disabled: bool = False  # Explicit acknowledgment for unauthenticated mode
     cors_origins: list[str] = []  # Empty = no CORS; set explicitly in production
     cors_allow_credentials: bool = False  # Set True only with specific origins, not "*"
     max_upload_size_mb: int = 20

--- a/src/pic/core/metrics.py
+++ b/src/pic/core/metrics.py
@@ -1,32 +1,8 @@
-"""Prometheus metrics for the PIC API.
+"""Prometheus metrics helpers for PIC-specific background job counters."""
 
-Defines application-level counters and histograms for HTTP request
-tracking and background job monitoring. These complement the
-auto-instrumentation provided by prometheus-fastapi-instrumentator
-and the database pool gauges in ``pic.core.database``.
-"""
+from prometheus_client import Counter
 
-from prometheus_client import Counter, Histogram
-
-# ---------------------------------------------------------------------------
-# HTTP request metrics
-# ---------------------------------------------------------------------------
-
-http_requests_total = Counter(
-    "http_requests_total",
-    "Total number of HTTP requests processed",
-    labelnames=["method", "endpoint", "status"],
-)
-
-http_request_duration_seconds = Histogram(
-    "http_request_duration_seconds",
-    "HTTP request duration in seconds",
-    labelnames=["method", "endpoint"],
-)
-
-# ---------------------------------------------------------------------------
-# Background job metrics
-# ---------------------------------------------------------------------------
+from pic.models.db import JobStatus, JobType
 
 jobs_created_total = Counter(
     "jobs_created_total",
@@ -36,6 +12,27 @@ jobs_created_total = Counter(
 
 jobs_completed_total = Counter(
     "jobs_completed_total",
-    "Total number of background jobs completed",
+    "Total number of background jobs that reached a terminal status",
     labelnames=["type", "status"],
 )
+
+
+def _job_type_label(job_type: JobType | str) -> str:
+    return job_type.name if isinstance(job_type, JobType) else str(job_type).upper()
+
+
+def _job_status_label(status: JobStatus | str) -> str:
+    return status.name if isinstance(status, JobStatus) else str(status).upper()
+
+
+def record_job_created(job_type: JobType | str) -> None:
+    """Increment the created-job counter."""
+    jobs_created_total.labels(type=_job_type_label(job_type)).inc()
+
+
+def record_job_finished(job_type: JobType | str, status: JobStatus | str) -> None:
+    """Increment the terminal job counter."""
+    jobs_completed_total.labels(
+        type=_job_type_label(job_type),
+        status=_job_status_label(status),
+    ).inc()

--- a/src/pic/modal_app.py
+++ b/src/pic/modal_app.py
@@ -92,6 +92,7 @@ async def _create_gdrive_sync_job_if_capacity() -> str | None:
 
     from pic.config import settings
     from pic.core.database import async_session
+    from pic.core.metrics import record_job_created
     from pic.models.db import Job, JobStatus, JobType
 
     async with async_session() as db:
@@ -105,6 +106,7 @@ async def _create_gdrive_sync_job_if_capacity() -> str | None:
         job_id = str(uuid.uuid4())
         db.add(Job(id=job_id, type=JobType.GDRIVE_SYNC, status=JobStatus.PENDING))
         await db.commit()
+        record_job_created(JobType.GDRIVE_SYNC)
         return job_id
 
 
@@ -112,6 +114,7 @@ async def _mark_job_failed(job_id: str, error: str) -> None:
     from sqlalchemy import update
 
     from pic.core.database import async_session
+    from pic.core.metrics import record_job_finished
     from pic.models.db import Job, JobStatus
 
     async with async_session() as db:
@@ -121,6 +124,7 @@ async def _mark_job_failed(job_id: str, error: str) -> None:
             .values(status=JobStatus.FAILED, error=error, completed_at=datetime.now(UTC))
         )
         await db.commit()
+    record_job_finished("GDRIVE_SYNC", JobStatus.FAILED)
 
 
 async def _check_gdrive_for_new_files_impl() -> None:

--- a/src/pic/worker/helpers.py
+++ b/src/pic/worker/helpers.py
@@ -10,7 +10,8 @@ from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pic.core.database import async_session
-from pic.models.db import Job, JobStatus
+from pic.core.metrics import record_job_finished
+from pic.models.db import Job, JobStatus, JobType
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,7 @@ async def check_modal_job_status(db: AsyncSession) -> int:
                         completed_at=datetime.now(UTC),
                     )
                 )
+                record_job_finished(job.type, JobStatus.FAILED)
                 updated += 1
         except Exception:
             logger.warning("Failed to check Modal status for job %s", job.id, exc_info=True)
@@ -118,6 +120,7 @@ async def mark_job_running(db: AsyncSession, job_id: str) -> None:
 
 async def mark_job_failed(db: AsyncSession, job_id: str, error: str) -> None:
     """Set job status to FAILED with error message and timestamp."""
+    job_type = await _load_job_type(db, job_id)
     await db.execute(
         update(Job)
         .where(Job.id == job_id)
@@ -128,6 +131,8 @@ async def mark_job_failed(db: AsyncSession, job_id: str, error: str) -> None:
         )
     )
     await db.commit()
+    if job_type is not None:
+        record_job_finished(job_type, JobStatus.FAILED)
 
 
 async def sweep_stale_jobs(db: AsyncSession, max_age_minutes: int | None = None) -> int:
@@ -141,9 +146,16 @@ async def sweep_stale_jobs(db: AsyncSession, max_age_minutes: int | None = None)
 
         max_age_minutes = settings.stale_job_timeout_minutes
     cutoff = datetime.now(UTC) - timedelta(minutes=max_age_minutes)
+    stale_jobs_result = await db.execute(
+        select(Job.id, Job.type).where(Job.status == JobStatus.RUNNING, Job.created_at < cutoff)
+    )
+    stale_jobs = stale_jobs_result.all()
+    if not stale_jobs:
+        return 0
+
     result = await db.execute(
         update(Job)
-        .where(Job.status == JobStatus.RUNNING, Job.created_at < cutoff)
+        .where(Job.id.in_([job_id for job_id, _ in stale_jobs]))
         .values(
             status=JobStatus.FAILED,
             error=f"Job timed out after {max_age_minutes} minutes",
@@ -153,12 +165,15 @@ async def sweep_stale_jobs(db: AsyncSession, max_age_minutes: int | None = None)
     await db.commit()
     swept: int = result.rowcount or 0  # type: ignore[attr-defined]
     if swept:
+        for _, job_type in stale_jobs:
+            record_job_finished(job_type, JobStatus.FAILED)
         logger.warning("Swept %d stale RUNNING jobs (older than %d min)", swept, max_age_minutes)
     return swept
 
 
 async def mark_job_completed(db: AsyncSession, job_id: str, result: dict[str, object]) -> None:
     """Set job status to COMPLETED with result JSON and timestamp."""
+    job_type = await _load_job_type(db, job_id)
     await db.execute(
         update(Job)
         .where(Job.id == job_id)
@@ -170,6 +185,15 @@ async def mark_job_completed(db: AsyncSession, job_id: str, result: dict[str, ob
         )
     )
     await db.commit()
+    if job_type is not None:
+        record_job_finished(job_type, JobStatus.COMPLETED)
+
+
+async def _load_job_type(db: AsyncSession, job_id: str) -> JobType | None:
+    """Load a job's type if it still exists."""
+    result = await db.execute(select(Job.type).where(Job.id == job_id))
+    job_type = result.scalar_one_or_none()
+    return job_type if isinstance(job_type, JobType) else None
 
 
 @asynccontextmanager

--- a/src/pic/worker/url_ingest.py
+++ b/src/pic/worker/url_ingest.py
@@ -14,6 +14,8 @@ from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pic.config import settings
+from pic.core.metrics import record_job_created, record_job_finished
+from pic.models.db import JobStatus, JobType
 from pic.services.url_safety import resolve_public_ips, validate_url_target
 
 logger = logging.getLogger(__name__)
@@ -94,12 +96,13 @@ async def _download_urls(urls: list[str]) -> list[DownloadResult]:
 
 async def _queue_auto_pipeline_job(db: AsyncSession) -> tuple[str | None, str | None]:
     """Create and dispatch a separate pipeline job for auto-pipeline mode."""
-    from pic.models.db import Job, JobStatus, JobType
+    from pic.models.db import Job
     from pic.services.modal_dispatch import submit_pipeline_job
 
     pipeline_job_id = str(uuid.uuid4())
     db.add(Job(id=pipeline_job_id, type=JobType.PIPELINE, status=JobStatus.PENDING))
     await db.commit()
+    record_job_created(JobType.PIPELINE)
 
     try:
         modal_call_id = await submit_pipeline_job(pipeline_job_id)
@@ -115,6 +118,7 @@ async def _queue_auto_pipeline_job(db: AsyncSession) -> tuple[str | None, str | 
             )
         )
         await db.commit()
+        record_job_finished(JobType.PIPELINE, JobStatus.FAILED)
         return None, "Failed to dispatch auto-pipeline job"
 
     if modal_call_id:
@@ -128,7 +132,7 @@ async def run_url_ingest(job_id: str, urls: list[str], auto_pipeline: bool = Fal
     """Download images from URLs, deduplicate, and store."""
     from pic.core.constants import S3_PREFIX_INBOX
     from pic.core.database import async_session
-    from pic.models.db import Image, Job, JobStatus
+    from pic.models.db import Image, Job
     from pic.services.image_store import upload_to_s3
     from pic.worker.image_processing import check_content_duplicate, compute_content_hash, insert_image_record
 
@@ -226,6 +230,7 @@ async def run_url_ingest(job_id: str, urls: list[str], auto_pipeline: bool = Fal
                 )
             )
             await db.commit()
+            record_job_finished(JobType.URL_INGEST, JobStatus.COMPLETED)
             logger.info("URL ingest job %s complete: %s", job_id, result)
     except Exception as exc:
         logger.exception("URL ingest job %s failed", job_id)
@@ -240,4 +245,5 @@ async def run_url_ingest(job_id: str, urls: list[str], auto_pipeline: bool = Fal
                 )
             )
             await db.commit()
+        record_job_finished(JobType.URL_INGEST, JobStatus.FAILED)
         raise

--- a/tests/unit/test_api_deps.py
+++ b/tests/unit/test_api_deps.py
@@ -1,0 +1,49 @@
+"""Unit tests for shared API dependency helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.mark.unit
+class TestCreateAndDispatchJob:
+    @pytest.mark.asyncio
+    async def test_records_created_metric_after_job_insert(self) -> None:
+        mock_db = AsyncMock()
+        mock_db.add = MagicMock()
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 0
+        mock_db.execute = AsyncMock(return_value=count_result)
+
+        dispatch_fn = AsyncMock(return_value="modal-call-1")
+
+        with patch("pic.api.deps.record_job_created") as mock_created:
+            from pic.api.deps import create_and_dispatch_job
+            from pic.models.db import JobType
+
+            job = await create_and_dispatch_job(mock_db, JobType.PIPELINE, dispatch_fn, None)
+
+        assert job.type == JobType.PIPELINE
+        mock_created.assert_called_once_with(JobType.PIPELINE)
+
+    @pytest.mark.asyncio
+    async def test_records_failed_metric_when_dispatch_fails(self) -> None:
+        mock_db = AsyncMock()
+        mock_db.add = MagicMock()
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 0
+        mock_db.execute = AsyncMock(return_value=count_result)
+        dispatch_fn = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with (
+            patch("pic.api.deps.record_job_created"),
+            patch("pic.api.deps.record_job_finished") as mock_finished,
+        ):
+            from pic.api.deps import create_and_dispatch_job
+            from pic.models.db import JobStatus, JobType
+
+            with pytest.raises(HTTPException, match="Failed to dispatch job"):
+                await create_and_dispatch_job(mock_db, JobType.CLUSTER_FULL, dispatch_fn, None)
+
+        mock_finished.assert_called_once_with(JobType.CLUSTER_FULL, JobStatus.FAILED)

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -293,6 +293,15 @@ class TestAuthGlobal:
                 response = c.post("/api/v1/search/similar", json={"image_id": "x"})
                 assert response.status_code == 401
 
+    def test_metrics_requires_auth(self):
+        with patch("pic.core.auth.settings") as mock_settings:
+            mock_settings.api_key = "secret-key"
+            from pic.main import app
+
+            with TestClient(app) as c:
+                response = c.get("/metrics")
+                assert response.status_code == 401
+
     def test_valid_key_passes(self, mock_db):
         with patch("pic.core.auth.settings") as mock_settings:
             mock_settings.api_key = "secret-key"

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -14,11 +14,14 @@ class TestSweepStaleJobs:
         return AsyncMock()
 
     async def test_sweeps_stale_running_jobs(self, mock_db):
+        from pic.models.db import JobType
         from pic.worker.helpers import sweep_stale_jobs
 
+        stale_jobs = MagicMock()
+        stale_jobs.all.return_value = [("job-1", JobType.PIPELINE), ("job-2", JobType.CLUSTER_FULL)]
         mock_result = MagicMock()
         mock_result.rowcount = 2
-        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.execute = AsyncMock(side_effect=[stale_jobs, mock_result])
 
         swept = await sweep_stale_jobs(mock_db, max_age_minutes=60)
 
@@ -28,34 +31,36 @@ class TestSweepStaleJobs:
     async def test_no_stale_jobs_returns_zero(self, mock_db):
         from pic.worker.helpers import sweep_stale_jobs
 
-        mock_result = MagicMock()
-        mock_result.rowcount = 0
-        mock_db.execute = AsyncMock(return_value=mock_result)
+        stale_jobs = MagicMock()
+        stale_jobs.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=stale_jobs)
 
         swept = await sweep_stale_jobs(mock_db, max_age_minutes=60)
 
         assert swept == 0
-        mock_db.commit.assert_awaited_once()
+        mock_db.commit.assert_not_awaited()
 
     async def test_custom_max_age(self, mock_db):
+        from pic.models.db import JobType
         from pic.worker.helpers import sweep_stale_jobs
 
+        stale_jobs = MagicMock()
+        stale_jobs.all.return_value = [("job-1", JobType.PIPELINE)]
         mock_result = MagicMock()
         mock_result.rowcount = 1
-        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.execute = AsyncMock(side_effect=[stale_jobs, mock_result])
 
         swept = await sweep_stale_jobs(mock_db, max_age_minutes=30)
 
         assert swept == 1
-        # Verify the update was called (SQL includes the custom timeout message)
-        mock_db.execute.assert_awaited_once()
+        assert mock_db.execute.await_count == 2
 
     async def test_default_max_age_is_60(self, mock_db):
         from pic.worker.helpers import sweep_stale_jobs
 
-        mock_result = MagicMock()
-        mock_result.rowcount = 0
-        mock_db.execute = AsyncMock(return_value=mock_result)
+        stale_jobs = MagicMock()
+        stale_jobs.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=stale_jobs)
 
         swept = await sweep_stale_jobs(mock_db)
 
@@ -79,19 +84,29 @@ class TestMarkJobHelpers:
         mock_db.commit.assert_awaited_once()
 
     async def test_mark_job_failed(self, mock_db):
+        from pic.models.db import JobType
         from pic.worker.helpers import mark_job_failed
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = JobType.PIPELINE
+        mock_db.execute = AsyncMock(side_effect=[mock_result, MagicMock()])
 
         await mark_job_failed(mock_db, "job-1", "something went wrong")
 
-        mock_db.execute.assert_awaited_once()
+        assert mock_db.execute.await_count == 2
         mock_db.commit.assert_awaited_once()
 
     async def test_mark_job_completed(self, mock_db):
+        from pic.models.db import JobType
         from pic.worker.helpers import mark_job_completed
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = JobType.PIPELINE
+        mock_db.execute = AsyncMock(side_effect=[mock_result, MagicMock()])
 
         await mark_job_completed(mock_db, "job-1", {"images_processed": 10})
 
-        mock_db.execute.assert_awaited_once()
+        assert mock_db.execute.await_count == 2
         mock_db.commit.assert_awaited_once()
 
 
@@ -115,17 +130,19 @@ class TestAcquireAdvisoryLock:
         assert acquired is True
 
     async def test_lock_not_acquired_marks_job_failed(self, mock_db):
+        from pic.models.db import JobType
         from pic.worker.helpers import acquire_advisory_lock
 
         mock_result = MagicMock()
         mock_result.scalar.return_value = False
-        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_job_type_result = MagicMock()
+        mock_job_type_result.scalar_one_or_none.return_value = JobType.PIPELINE
+        mock_db.execute = AsyncMock(side_effect=[mock_result, mock_job_type_result, MagicMock()])
 
         acquired = await acquire_advisory_lock(mock_db, 0x4E494301, "job-1")
 
         assert acquired is False
-        # Should have called execute twice: once for lock, once for marking failed
-        assert mock_db.execute.await_count == 2
+        assert mock_db.execute.await_count == 3
 
 
 @pytest.mark.unit

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,19 +1,15 @@
-"""Unit tests for metrics module symbols."""
+"""Unit tests for metrics helpers."""
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter
 
 from pic.core import metrics
 
 
 def test_metrics_objects_are_declared_with_expected_types() -> None:
-    assert isinstance(metrics.http_requests_total, Counter)
-    assert isinstance(metrics.http_request_duration_seconds, Histogram)
     assert isinstance(metrics.jobs_created_total, Counter)
     assert isinstance(metrics.jobs_completed_total, Counter)
 
 
-def test_metrics_can_record_values() -> None:
-    metrics.http_requests_total.labels(method="GET", endpoint="/health", status="200").inc()
-    metrics.http_request_duration_seconds.labels(method="GET", endpoint="/health").observe(0.01)
-    metrics.jobs_created_total.labels(type="PIPELINE").inc()
-    metrics.jobs_completed_total.labels(type="PIPELINE", status="COMPLETED").inc()
+def test_metrics_helper_functions_accept_strings_and_normalize_labels() -> None:
+    metrics.record_job_created("pipeline")
+    metrics.record_job_finished("pipeline", "completed")

--- a/tests/unit/test_modal_app.py
+++ b/tests/unit/test_modal_app.py
@@ -143,3 +143,48 @@ def test_parse_url_ingest_params_rejects_non_boolean_auto_pipeline() -> None:
 
     with pytest.raises(TypeError, match="must be a boolean"):
         _parse_url_ingest_params(json.dumps({"urls": ["https://example.com/a.jpg"], "auto_pipeline": "yes"}))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_gdrive_sync_job_records_created_metric() -> None:
+    mock_db = AsyncMock()
+    mock_db.add = MagicMock()
+    mock_pending_result = MagicMock()
+    mock_pending_result.scalar_one.return_value = 0
+    mock_db.execute = AsyncMock(return_value=mock_pending_result)
+
+    with (
+        patch("pic.core.database.async_session") as mock_session,
+        patch("pic.core.metrics.record_job_created") as mock_record,
+        patch("pic.config.settings") as mock_settings,
+    ):
+        mock_settings.job_queue_max_pending = 100
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        from pic.modal_app import _create_gdrive_sync_job_if_capacity
+
+        job_id = await _create_gdrive_sync_job_if_capacity()
+
+    assert job_id is not None
+    mock_record.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mark_job_failed_records_failed_metric() -> None:
+    mock_db = AsyncMock()
+
+    with (
+        patch("pic.core.database.async_session") as mock_session,
+        patch("pic.core.metrics.record_job_finished") as mock_record,
+    ):
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        from pic.modal_app import _mark_job_failed
+
+        await _mark_job_failed("job-123", "boom")
+
+    mock_record.assert_called_once()


### PR DESCRIPTION
## Summary
- make PIC-specific background job metrics live by incrementing created/completed counters at the actual job lifecycle points
- update monitoring guidance to describe the real `/metrics` auth behavior and the actual instrumentator metric names available at runtime
- sweep README, deployment docs, Google Drive setup docs, and AGENTS.md for current auth/config/worker/runtime behavior

## Testing
- uv run ruff check src/ tests/ scripts/
- uv run ruff format --check src/ tests/ scripts/
- uv run mypy src/pic/
- uv run pytest -m unit
- uv run pip-audit

## Notes
- Chose a mixed fix: implemented the useful custom job metrics and updated docs to rely on instrumentator-provided HTTP metrics instead of documenting nonexistent custom HTTP counters.

Fixes #52
Fixes #53