### PR TITLE
docs: correct v0.2.1 notes and validate technical debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-16
+
+### Added
+- Background job lifecycle metrics for ingest, clustering, pipeline, and Google Drive sync workers
+
+### Fixed
+- Restore URL-ingest Modal dispatch and follow-up job chaining (#54)
+- Block SSRF-style URL-ingest targets across direct requests, DNS resolution, and redirect hops (#49)
+- Require explicit auth opt-out instead of silently disabling auth when `PIC_API_KEY` is unset (#50)
+
+### Changed
+- Document authenticated `/metrics` behavior and align monitoring docs with the live Prometheus metric set (#52)
+- Reconcile README, deployment guides, Google Drive setup docs, and contributor guidance with the current runtime behavior (#53)
+- Skip docs-only CI runs and skip Modal deployment when Modal secrets are not configured (#45)
+
 ## [0.2.0] - 2026-03-15
 
 ### Added
@@ -21,11 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Support shared rate limit storage for multi-instance deployments (#17)
 - Make Google Drive OAuth scopes configurable (#8)
-- Restore URL-ingest Modal dispatch by exporting the `run_url_ingest` worker entrypoint
-- Track `auto_pipeline` follow-up work as a separate pipeline job instead of reusing the URL-ingest job
-- Refactor URL-ingest worker to avoid concurrent reuse of a single async DB session
-- Block SSRF-style URL-ingest targets across direct requests and redirect hops (#49)
-- Require explicit auth opt-out instead of silently disabling auth when `PIC_API_KEY` is unset (#50)
 
 ### Changed
 - Split `main.py` into `core/middleware.py`, `core/exception_handlers.py`, and `api/health.py`
@@ -48,5 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker Compose for local development
 - CI/CD pipeline with GitHub Actions
 
+[0.2.1]: https://github.com/masa-57/pic/releases/tag/v0.2.1
 [0.2.0]: https://github.com/masa-57/pic/releases/tag/v0.2.0
 [0.1.0]: https://github.com/masa-57/pic/releases/tag/v0.1.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,10 @@
 # Roadmap
 
-This document outlines planned improvements for PIC. Contributions are welcome for any of these items.
+This document outlines likely next improvements for PIC. Contributions are
+welcome for any of these items.
+
+There are currently no open roadmap issues. The items below are prospective
+next investments rather than committed milestones.
 
 ## High Priority
 
@@ -49,3 +53,21 @@ Support for S3 (existing), Google Cloud Storage, and local filesystem via `PIC_S
 ### URL-Based Image Ingestion
 
 `POST /api/v1/images/ingest` endpoint accepts image URLs for batch download and ingestion. See [design doc](docs/plans/2026-03-04-storage-backends-and-url-ingestion-design.md).
+
+### URL Ingest Hardening And Worker Reliability
+
+`POST /api/v1/images/ingest` now blocks private and local-network targets,
+revalidates redirect hops, and restores correct Modal dispatch and follow-up job
+chaining.
+
+### Explicit Auth Opt-Out And Metrics Alignment
+
+Auth now requires an explicit `PIC_AUTH_DISABLED=true` opt-out, and the
+documented `/metrics` behavior matches the live authenticated endpoint and
+background job metrics.
+
+### Documentation Reconciliation
+
+README, deployment guides, Google Drive setup docs, changelog entries, and
+contributor guidance were brought back in sync with the deployed system after
+the `v0.2.1` release.

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -1,6 +1,6 @@
 # Technical Debt
 
-Last updated: 2026-02-24
+Last updated: 2026-03-16
 
 ## Overview
 
@@ -10,28 +10,40 @@ high-level summary of known areas for improvement.
 For the full list of open issues, see:
 [GitHub Issues](https://github.com/masa-57/pic/issues?q=is%3Aissue+is%3Aopen)
 
-## Known Areas
+The items below were validated against the current codebase on 2026-03-16 and
+are now tracked as open GitHub issues.
+
+## Current Watch Areas
 
 ### Performance
 
-- Serial S3 operations in some worker paths could benefit from concurrency
-- Visualization endpoint loads all images into memory (needs pagination)
-- Some API list endpoints issue sequential DB queries that could be parallelized
+- [#58](https://github.com/masa-57/pic/issues/58) Optimize Google Drive sync
+  batch processing to reduce serial storage work
+- [#59](https://github.com/masa-57/pic/issues/59) Paginate or stream the
+  cluster visualization instead of loading the full hierarchy into memory
+- [#60](https://github.com/masa-57/pic/issues/60) Reduce redundant database
+  round trips in list and summary API endpoints
 
 ### Architecture
 
-- API layer contains direct `db.execute()` calls that could be extracted into a service layer
+- [#61](https://github.com/masa-57/pic/issues/61) Extract database-heavy API
+  route logic into service-layer functions
+- [#62](https://github.com/masa-57/pic/issues/62) Introduce a worker
+  dispatcher abstraction to decouple ML job submission from Modal
 
 ### Testing
 
-- Several service modules have low or no direct test coverage
-- Integration test embeddings use simplified vectors that don't fully exercise similarity logic
+- [#63](https://github.com/masa-57/pic/issues/63) Raise automated coverage on
+  low-covered worker and service modules
+- [#64](https://github.com/masa-57/pic/issues/64) Add higher-fidelity
+  clustering integration tests that exercise real similarity behavior
 
 ### DevOps
 
-- Staging workflow has fewer quality gates than the production CI/CD pipeline
+- [#65](https://github.com/masa-57/pic/issues/65) Align the staging workflow
+  quality gates with main CI/CD
 
-## Previously Resolved
+## Recently Retired
 
 Multiple reviews identified and resolved 150+ issues including:
 
@@ -42,3 +54,7 @@ Multiple reviews identified and resolved 150+ issues including:
 - CI/CD hardening (permissions, rollback mechanism, container scanning)
 - Error response consistency (RFC 7807 ProblemDetail)
 - Presigned URL cache TTL
+- URL-ingest worker dispatch and follow-up job chaining regressions (#54)
+- SSRF protections for URL ingestion, including redirect and DNS checks (#49)
+- Explicit auth opt-out and authenticated `/metrics` behavior documentation (#50, #52)
+- README, deployment docs, and contributor guide drift from the live system (#53)


### PR DESCRIPTION
## Summary
- add the missing `v0.2.1` changelog entry and move post-`v0.2.0` fixes into the correct release bucket
- update the roadmap and technical debt docs to reflect the current project state after the March 16 release work
- validate each technical debt item against the codebase and track the confirmed items as GitHub issues `#58` through `#65`

## Validation
- `uv run pytest -m unit --cov=src/pic --cov-report=term`
- `git diff --check`
